### PR TITLE
fix: correct indentation of top level lists (#5)

### DIFF
--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -33,7 +33,7 @@ def test_fix_code_doesnt_double_the_header() -> None:
 
 
 def test_fix_code_corrects_indentation_on_lists() -> None:
-    """Use two spaces for indentation."""
+    """Use two spaces for indentation of lists."""
     source = dedent(
         """\
         ---
@@ -52,6 +52,20 @@ def test_fix_code_corrects_indentation_on_lists() -> None:
     result = fix_code(source)
 
     assert result == fixed_source
+
+
+def test_fix_code_respects_parent_lists() -> None:
+    """Do not indent lists at the first level."""
+    source = dedent(
+        """\
+        ---
+        - item1
+        - item2"""
+    )
+
+    result = fix_code(source)
+
+    assert result == source
 
 
 def test_fix_code_preserves_comments() -> None:


### PR DESCRIPTION
<!--
Thank you for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is, try to link it with open issues -->
Correct indentation of top level lists, closes #5 

Also refactored _add_heading in favour of explicit_start attribute

ruyaml parser has the attribute explicit_start which does the same.

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
