### PR TITLE
ci: disable safety pre-commit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,3 @@
-<!--
-Thank you for sending a pull request!
-Please fill in the following content to let us know better about this change.
--->
-
-## Description
 <!-- Describe what the change is, try to link it with open issues -->
 
 ## Checklist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,6 @@ repos:
         id: mypy
         args: [--no-warn-unused-ignores, --ignore-missing-imports]
         files: src
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.1.3
-    hooks:
-      - id: python-safety-dependencies-check
   - repo: https://github.com/life4/flakehell/
     rev: master
     hooks:


### PR DESCRIPTION
Otherwise the update pipeline fails due to the tornadoweb issue [#2981](https://github.com/tornadoweb/tornado/issues/2981)

<!--
Thank you for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is, try to link it with open issues -->

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
