### PR TITLE
fix: respect anchors in urls

### DIFF
--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -250,7 +250,7 @@ def _fix_comments(source_code: str) -> str:
     fixed_source_lines = []
 
     for line in source_code.splitlines():
-        if re.search(r"#\w", line):
+        if re.search(r"(^|\s)#\w", line):
             line = line.replace("#", "# ")
         if re.match(r".+\S\s#", line):
             line = line.replace(" #", "  #")

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -292,6 +292,20 @@ def test_fix_code_add_space_inline_comment() -> None:
     assert result == fixed_source
 
 
+def test_fix_code_respects_url_anchors() -> None:
+    """Comments that contain a url with an anchor should be respected."""
+    source = dedent(
+        """\
+        ---
+        # https://lyz-code.github.io/yamlfix/#usage
+        foo: bar"""
+    )
+
+    result = fix_code(source)
+
+    assert result == source
+
+
 def test_fix_code_add_extra_space_inline_comment() -> None:
     """Fix inline comments that don't have two spaces before
     the #.


### PR DESCRIPTION
Code like:

```yaml
---
# https://lyz-code.github.io/yamlfix/#usage
foo: bar
```

Got indented as:

```yaml
---
#  https://lyz-code.github.io/yamlfix/ #usage
foo: bar
```

Thus breaking the link. This commit fixes that behaviour and closes #70

<!-- Describe what the change is, try to link it with open issues -->

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
