### PR TITLE
chore: update requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,8 +192,7 @@ security:
 	@echo "- Testing security -"
 	@echo "--------------------"
 
-	# There is currently no fix [#2981](https://github.com/tornadoweb/tornado/issues/2981)
-	safety check -i 39462
+	safety check
 	@echo ""
 	bandit -r src
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -30,7 +30,7 @@ htmlmin==0.1.12
     # via mkdocs-minify-plugin
 idna==2.10
     # via requests
-importlib-metadata==3.7.2
+importlib-metadata==3.7.3
     # via markdown
 jinja2==2.11.3
     # via
@@ -68,7 +68,7 @@ mkdocs-htmlproofer-plugin==0.1.0
     # via -r docs/requirements.in
 mkdocs-material-extensions==1.0.1
     # via mkdocs-material
-mkdocs-material==7.0.5
+mkdocs-material==7.0.6
     # via
     #   -r docs/requirements.in
     #   mkdocs-material-extensions
@@ -100,7 +100,7 @@ pytz==2021.1
     # via babel
 pyyaml==5.4.1
     # via mkdocs
-regex==2020.11.13
+regex==2021.3.17
     # via nltk
 requests==2.25.1
     # via mkdocs-htmlproofer-plugin
@@ -123,7 +123,7 @@ typing-extensions==3.7.4.3
     # via
     #   importlib-metadata
     #   pytkdocs
-urllib3==1.26.3
+urllib3==1.26.4
     # via requests
 wheel==0.36.2
     # via astunparse

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -85,7 +85,7 @@ flake8-aaa==0.11.1
     # via -r requirements-dev.in
 flake8-annotations-complexity==0.0.6
     # via -r requirements-dev.in
-flake8-annotations==2.6.0
+flake8-annotations==2.6.1
     # via -r requirements-dev.in
 flake8-bugbear==21.3.2
     # via -r requirements-dev.in
@@ -109,7 +109,7 @@ flake8-plugin-utils==1.3.1
     # via flake8-pytest-style
 flake8-polyfill==1.0.2
     # via pep8-naming
-flake8-pytest-style==1.3.0
+flake8-pytest-style==1.4.0
     # via -r requirements-dev.in
 flake8-pytest==1.3
     # via -r requirements-dev.in
@@ -121,7 +121,7 @@ flake8-use-fstring==1.1
     # via -r requirements-dev.in
 flake8-variables-names==0.0.4
     # via -r requirements-dev.in
-flake8==3.8.4
+flake8==3.9.0
     # via
     #   dlint
     #   flake8-annotations
@@ -158,13 +158,13 @@ htmlmin==0.1.12
     # via
     #   -r docs/requirements.txt
     #   mkdocs-minify-plugin
-identify==2.1.2
+identify==2.1.3
     # via pre-commit
 idna==2.10
     # via
     #   -r docs/requirements.txt
     #   requests
-importlib-metadata==3.7.2
+importlib-metadata==3.7.3
     # via
     #   -r docs/requirements.txt
     #   flake8
@@ -172,6 +172,7 @@ importlib-metadata==3.7.2
     #   flake8-simplify
     #   flake8-typing-imports
     #   markdown
+    #   pep517
     #   pluggy
     #   pre-commit
     #   pytest
@@ -248,7 +249,7 @@ mkdocs-material-extensions==1.0.1
     # via
     #   -r docs/requirements.txt
     #   mkdocs-material
-mkdocs-material==7.0.5
+mkdocs-material==7.0.6
     # via
     #   -r docs/requirements.in
     #   -r docs/requirements.txt
@@ -295,9 +296,11 @@ pathspec==0.8.1
     #   yamllint
 pbr==5.5.1
     # via stevedore
+pep517==0.10.0
+    # via pip-tools
 pep8-naming==0.11.1
     # via -r requirements-dev.in
-pip-tools==5.5.0
+pip-tools==6.0.1
     # via -r requirements-dev.in
 pluggy==0.13.1
     # via pytest
@@ -305,13 +308,13 @@ pre-commit==2.11.1
     # via -r requirements-dev.in
 py==1.10.0
     # via pytest
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via
     #   flake8
     #   flake8-debugger
 pydocstyle==5.1.1
     # via flake8-docstrings
-pyflakes==2.2.0
+pyflakes==2.3.0
     # via
     #   autoflake
     #   flake8
@@ -356,7 +359,7 @@ pyyaml==5.4.1
     #   mkdocs
     #   pre-commit
     #   yamllint
-regex==2020.11.13
+regex==2021.3.17
     # via
     #   -r docs/requirements.txt
     #   black
@@ -403,6 +406,7 @@ toml==0.10.2
     #   black
     #   dparse
     #   flakehell
+    #   pep517
     #   pre-commit
     #   pylint
     #   pytest
@@ -428,12 +432,12 @@ typing-extensions==3.7.4.3
     #   importlib-metadata
     #   mypy
     #   pytkdocs
-urllib3==1.26.3
+urllib3==1.26.4
     # via
     #   -r docs/requirements.txt
     #   flakehell
     #   requests
-virtualenv==20.4.2
+virtualenv==20.4.3
     # via pre-commit
 wheel==0.36.2
     # via
@@ -447,11 +451,12 @@ zipp==3.4.1
     # via
     #   -r docs/requirements.txt
     #   importlib-metadata
+    #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.0.1
     # via pip-tools
-setuptools==54.1.1
+setuptools==54.1.2
     # via
     #   flake8-annotations-complexity
     #   flake8-expression-complexity

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -43,7 +43,7 @@ def test_corrects_one_file(runner: CliRunner, tmpdir) -> None:
     assert test_file.read() == fixed_source
 
 
-@pytest.mark.secondary
+@pytest.mark.secondary()
 def test_corrects_three_files(runner: CliRunner, tmpdir) -> None:
     """Correct the source code of multiple files."""
     test_files = []


### PR DESCRIPTION
ci: remove the security bypass of 39462

style: use pytest.mark.secondary()

@pytest.mark.secondary started to break the linter

<!-- Describe what the change is, try to link it with open issues -->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
