### PR TITLE
feat: Allow formatting files with multiple documents

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
   - repo: https://github.com/ambv/black
-    rev: master
+    rev: main
     hooks:
       - id: black
         language_version: python3.7

--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -96,12 +96,13 @@ def _ruamel_yaml_fixer(source_code: str) -> str:
     # Start the document with ---
     # ignore: variable has type None, what can we do, it doesn't have type hints...
     yaml.explicit_start = True  # type: ignore
-    source_dict = yaml.load(source_code)
+    source_dicts = yaml.load_all(source_code)
 
     # Return the output to a string
     string_stream = StringIO()
-    yaml.dump(source_dict, string_stream)
-    source_code = string_stream.getvalue()
+    for source_dict in source_dicts:
+        yaml.dump(source_dict, string_stream)
+        source_code = string_stream.getvalue()
     string_stream.close()
 
     return source_code.strip()

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -339,3 +339,20 @@ def test_fix_code_doesnt_change_double_exclamation_marks() -> None:
     result = fix_code(source)
 
     assert result == source
+
+
+def test_fix_code_parses_files_with_multiple_documents() -> None:
+    """Files that contain multiple documents should be parsed as a collection of
+    separate documents and then dumped together again.
+    """
+    source = dedent(
+        """\
+        ---
+        project: yamlfix
+        ---
+        project: yamlfix"""
+    )
+
+    result = fix_code(source)
+
+    assert result == source


### PR DESCRIPTION
This PR fixes issue https://github.com/lyz-code/yamlfix/issues/9.

As indicated in the issue, I checked the [ruyaml options](https://github.com/pycontribs/ruyaml/blob/725bccd8aed1cd2aec746eae2a7c910739511d94/lib/ruamel/yaml/main.py#L141-L168) to see if there was any support for multiple files but this feature is already supported in the original [PyYAML library](https://pyyaml.org/wiki/PyYAMLDocumentation) and ruyaml follows the same strategy.

So I made the following changes:

- Added support for multiple file documents by using `load_all` instead of `load` and then iterating through the results to dump them to the stream.
- Added a test case to check if multiple document files are parsed. I didn't add tests for format fixes in multiple document files since the logic for the other fixes does not depend on whether the file has one or more documents (and no changes were made to those functions).
- Changed black rev to `main` in pre-commit config file, since `master` doesn't exist anymore and it was making pre-commit fail.
- Made no changes to the documentation because there were no references to lack of support for multiple document files.