### PR TITLE
feat: Add logging with tests

### DIFF
--- a/src/yamlfix/entrypoints/__init__.py
+++ b/src/yamlfix/entrypoints/__init__.py
@@ -31,8 +31,7 @@ class ConsoleColorFormatter(logging.Formatter):
         return super().format(record)
 
 
-# I have no idea how to test this function :(. If you do, please send a PR.
-def load_logger(verbose: bool = False) -> None:  # pragma no cover
+def load_logger(verbose: bool = False) -> None:
     """Configure the Logging logger.
 
     Args:

--- a/src/yamlfix/entrypoints/__init__.py
+++ b/src/yamlfix/entrypoints/__init__.py
@@ -7,7 +7,28 @@ Functions:
 import logging
 import sys
 
-log = logging.getLogger(__name__)
+# Ansi color codes
+RED = 31
+YELLOW = 33
+CYAN = 36
+GREEN = 32
+
+
+class ConsoleColorFormatter(logging.Formatter):
+    """Custom formatter that prints log levels to the console as colored plus signs."""
+
+    colors = {
+        logging.DEBUG: GREEN,
+        logging.INFO: CYAN,
+        logging.WARNING: YELLOW,
+        logging.ERROR: RED,
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format log records as a colored plus sign followed by the log message."""
+        color = self.colors.get(record.levelno, 0)
+        self._style._fmt = f"[\033[{color}m+\033[0m] %(message)s"
+        return super().format(record)
 
 
 # I have no idea how to test this function :(. If you do, please send a PR.
@@ -17,15 +38,7 @@ def load_logger(verbose: bool = False) -> None:  # pragma no cover
     Args:
         verbose: Set the logging level to Debug.
     """
-    logging.addLevelName(logging.INFO, "[\033[36m+\033[0m]")
-    logging.addLevelName(logging.ERROR, "[\033[31m+\033[0m]")
-    logging.addLevelName(logging.DEBUG, "[\033[32m+\033[0m]")
-    logging.addLevelName(logging.WARNING, "[\033[33m+\033[0m]")
-    if verbose:
-        logging.basicConfig(
-            stream=sys.stderr, level=logging.DEBUG, format="  %(levelname)s %(message)s"
-        )
-    else:
-        logging.basicConfig(
-            stream=sys.stderr, level=logging.INFO, format="  %(levelname)s %(message)s"
-        )
+    log_level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(stream=sys.stderr, level=log_level)
+    for handler in logging.getLogger().handlers:
+        handler.setFormatter(ConsoleColorFormatter())

--- a/src/yamlfix/entrypoints/cli.py
+++ b/src/yamlfix/entrypoints/cli.py
@@ -19,7 +19,7 @@ def _format_file_list(files: Tuple[TextIOWrapper]) -> str:
 @click.command()
 @click.version_option(version="", message=version.version_info())
 @click.option("--verbose", is_flag=True, help="Enable verbose logging.")
-@click.argument("files", type=click.File("r+"), nargs=-1)
+@click.argument("files", type=click.File("r+"), required=True, nargs=-1)
 def cli(files: Tuple[str], verbose: bool) -> None:
     """Corrects the source code of the specified files."""
     load_logger(verbose)

--- a/src/yamlfix/entrypoints/cli.py
+++ b/src/yamlfix/entrypoints/cli.py
@@ -1,21 +1,34 @@
 """Command line interface definition."""
-
+import logging
 from typing import Tuple
 
 import click
+from _io import TextIOWrapper
 
 from yamlfix import services, version
+from yamlfix.entrypoints import load_logger
+
+log = logging.getLogger(__name__)
+
+
+def _format_file_list(files: Tuple[TextIOWrapper]) -> str:
+    file_names = [file.name for file in files]
+    return "\n  - ".join([""] + file_names)
 
 
 @click.command()
 @click.version_option(version="", message=version.version_info())
+@click.option("--verbose", is_flag=True, help="Enable verbose logging.")
 @click.argument("files", type=click.File("r+"), nargs=-1)
-def cli(files: Tuple[str]) -> None:
+def cli(files: Tuple[str], verbose: bool) -> None:
     """Corrects the source code of the specified files."""
+    load_logger(verbose)
+    log.info("Fixing files:%s", _format_file_list(files))
     fixed_code = services.fix_files(files)
 
     if fixed_code is not None:
         print(fixed_code, end="")
+    log.info("Done.")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -3,13 +3,15 @@
 Classes and functions that connect the different domain model objects with the adapters
 and handlers to achieve the program's purpose.
 """
-
+import logging
 import re
 from io import StringIO
 from typing import List, Optional, Tuple
 
 import ruyaml
 from _io import TextIOWrapper
+
+log = logging.getLogger(__name__)
 
 
 def fix_files(files: Tuple[TextIOWrapper]) -> Optional[str]:
@@ -24,6 +26,7 @@ def fix_files(files: Tuple[TextIOWrapper]) -> Optional[str]:
         Fixed code retrieved from stdin or None.
     """
     for file_wrapper in files:
+        log.debug("Fixing file %s...", file_wrapper.name)
         source = file_wrapper.read()
         fixed_source = fix_code(source)
 
@@ -44,6 +47,7 @@ def fix_files(files: Tuple[TextIOWrapper]) -> Optional[str]:
             file_wrapper.seek(0)
             file_wrapper.write(fixed_source)
             file_wrapper.truncate()
+            log.debug("Fixed file %s.", file_wrapper.name)
         else:
             return fixed_source
 
@@ -89,6 +93,7 @@ def _ruamel_yaml_fixer(source_code: str) -> str:
     Returns:
         Corrected source code.
     """
+    log.debug("Running ruamel yaml fixer...")
     # Configure YAML formatter
     yaml = ruyaml.main.YAML()
     yaml.indent(mapping=2, sequence=4, offset=2)
@@ -137,6 +142,7 @@ def _fix_top_level_lists(source_code: str) -> str:
     Returns:
         Corrected source code.
     """
+    log.debug("Fixing top level lists...")
     source_lines = source_code.splitlines()
     fixed_source_lines: List[str] = []
     is_top_level_list: Optional[bool] = None
@@ -190,6 +196,7 @@ def _fix_truthy_strings(source_code: str) -> str:
     Returns:
         Corrected source code.
     """
+    log.debug("Fixing truthy strings...")
     source_lines = source_code.splitlines()
     fixed_source_lines: List[str] = []
 
@@ -230,6 +237,7 @@ def _restore_truthy_strings(source_code: str) -> str:
     Returns:
         Corrected source code.
     """
+    log.debug("Restoring truthy strings...")
     source_lines = source_code.splitlines()
     fixed_source_lines: List[str] = []
 
@@ -251,6 +259,7 @@ def _restore_truthy_strings(source_code: str) -> str:
 
 
 def _fix_comments(source_code: str) -> str:
+    log.debug("Fixing comments...")
     fixed_source_lines = []
 
     for line in source_code.splitlines():
@@ -269,6 +278,7 @@ def _restore_double_exclamations(source_code: str) -> str:
     The Ruyaml parser transforms the !!python statement to !%21python which breaks
     some programs.
     """
+    log.debug("Restoring double exclamations...")
     fixed_source_lines = []
     double_exclamation = re.compile(r"!%21")
 

--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -29,27 +29,15 @@ def fix_files(files: Tuple[TextIOWrapper]) -> Optional[str]:
         log.debug("Fixing file %s...", file_wrapper.name)
         source = file_wrapper.read()
         fixed_source = fix_code(source)
+        log.warning(file_wrapper.name)
 
-        try:
-            # Click testing runner doesn't simulate correctly the reading from stdin
-            # instead of setting the name attribute to `<stdin>` it gives an
-            # AttributeError. But when you use it outside testing, no AttributeError
-            # is raised and name has the value <stdin>. So there is no way of testing
-            # this behaviour.
-            if file_wrapper.name == "<stdin>":  # pragma: no cover
-                output = "output"
-            else:
-                output = "file"
-        except AttributeError:
-            output = "output"
-
-        if output == "file":
+        if file_wrapper.name == "<stdin>":
+            return fixed_source
+        else:
             file_wrapper.seek(0)
             file_wrapper.write(fixed_source)
             file_wrapper.truncate()
             log.debug("Fixed file %s.", file_wrapper.name)
-        else:
-            return fixed_source
 
     return None
 

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -1,5 +1,6 @@
 """Test the command line interface."""
 
+import logging
 import re
 from textwrap import dedent
 
@@ -80,3 +81,22 @@ def test_corrects_code_from_stdin(runner: CliRunner) -> None:
 
     assert result.exit_code == 0
     assert result.stdout == fixed_source
+
+
+@pytest.mark.secondary()
+@pytest.mark.parametrize("verbose", [True, False])
+def test_verbose_option(runner: CliRunner, verbose: bool) -> None:
+    """Prints debug level logs only when called with --verbose"""
+    # Clear logging handlers for logs to work with CliRunner
+    # For more info see https://github.com/pallets/click/issues/1053)
+    logging.getLogger().handlers = []
+    source = "program: yamlfix"
+    args = ["-", "--verbose"] if verbose else ["-"]
+
+    result = runner.invoke(cli, args, input=source)
+
+    debug_log_format = "[\033[32m+\033[0m]"
+    if verbose:
+        assert debug_log_format in result.stderr
+    else:
+        assert debug_log_format not in result.stderr

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,5 +1,6 @@
 """Tests the service layer."""
 
+import logging
 from textwrap import dedent
 
 import pytest
@@ -356,3 +357,22 @@ def test_fix_code_parses_files_with_multiple_documents() -> None:
     result = fix_code(source)
 
     assert result == source
+
+
+def test_fix_code_functions_emit_debug_logs(caplog: pytest.LogCaptureFixture) -> None:
+    """Each fixer function should emit a log at the debug level in each run."""
+    caplog.set_level(logging.DEBUG)
+
+    fix_code("")  # act
+
+    expected_logs = [
+        "Fixing truthy strings...",
+        "Fixing comments...",
+        "Running ruamel yaml fixer...",
+        "Restoring truthy strings...",
+        "Restoring double exclamations...",
+        "Fixing top level lists...",
+    ]
+    assert caplog.messages == expected_logs
+    for record in caplog.records:
+        assert record.levelname == "DEBUG"


### PR DESCRIPTION
Description of the changes:

- Added a custom logging formatter for the colored plus signs, instead of setting them as replacement for level names. I did this to be able to keep the level names, as they can be useful to test logging (since they are more readable than the ANSI sequences).
- Added the `--verbose` flag to the CLI and loaded the logger. Added two INFO logs to indicate that yamlfix is running and DEBUG logs for each file and fixer.
- Added a CLI test for the `--verbose` flag (checking stderr) and also a unit test for the DEBUG logs in the fixer functions (using the pytest caplog fixture).
- Marked the `files` argument as required, because if that argument is not present running `yamlfix` is a no-op.
- Removed the workaround for the `CliRunner` error in the stdin tests because I wasn't able to reproduce it. All tests pass, so it looks like the issue was resolved at some point. As a double check, I logged the file name and tested it with caplog in the corresponding test, to see if the `CliRunner` was keeping the name `<stdin>`, and it was:

```
____________________________________ test_corrects_code_from_stdin _______________________________________
[gw3] linux -- Python 3.7.11 /home/muri/Code/yamlfix/env/bin/python
tests/e2e/test_cli.py:82: in test_corrects_code_from_stdin
    assert caplog.records == []
E   assert [<LogRecord: yamlfix.services, 30, /home/muri/Code/yamlfix/src/yamlfix/services.py, 32, "<stdin>">] == []
E     Left contains one more item: <LogRecord: yamlfix.services, 30, /home/muri/Code/yamlfix/src/yamlfix/services.py, 32, "<stdin>">
```

Did not make any updates to the doc because there were no references to the aspects modified.

Coverage is now 100% :)

Hope you like the changes and looking forward to your feedback!