### PR TITLE
fix: add newline at end of file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ yamlfix will do the following changes in your code:
     'True' -> true, 'no' -> 'false'
 * Remove unnecessary apostrophes: `title: 'Why we sleep'` -> `title: Why we sleep`.
 * [Correct comments](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.comments)
+* Ensure that there is exactly one newline at the end of each file, to comply with the [POSIX standard](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206).
 
 # References
 

--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -64,6 +64,7 @@ def fix_code(source_code: str) -> str:
         _restore_truthy_strings,
         _restore_double_exclamations,
         _fix_top_level_lists,
+        _add_newline_at_end_of_file,
     ]
     for fixer in fixers:
         source_code = fixer(source_code)
@@ -275,3 +276,7 @@ def _restore_double_exclamations(source_code: str) -> str:
         fixed_source_lines.append(line)
 
     return "\n".join(fixed_source_lines)
+
+
+def _add_newline_at_end_of_file(source_code: str) -> str:
+    return source_code + "\n"

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -37,7 +37,8 @@ def test_corrects_one_file(runner: CliRunner, tmpdir: LocalPath) -> None:
     fixed_source = dedent(
         """\
         ---
-        program: yamlfix"""
+        program: yamlfix
+        """
     )
 
     result = runner.invoke(cli, [str(test_file)])
@@ -58,7 +59,8 @@ def test_corrects_three_files(runner: CliRunner, tmpdir: LocalPath) -> None:
     fixed_source = dedent(
         """\
         ---
-        program: yamlfix"""
+        program: yamlfix
+        """
     )
 
     result = runner.invoke(cli, [str(test_file) for test_file in test_files])
@@ -74,7 +76,8 @@ def test_corrects_code_from_stdin(runner: CliRunner) -> None:
     fixed_source = dedent(
         """\
         ---
-        program: yamlfix"""
+        program: yamlfix
+        """
     )
 
     result = runner.invoke(cli, ["-"], input=source)

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -38,7 +38,8 @@ def test_fix_code_adds_header() -> None:
     fixed_source = dedent(
         """\
         ---
-        program: yamlfix"""
+        program: yamlfix
+        """
     )
 
     result = fix_code(source)
@@ -51,7 +52,8 @@ def test_fix_code_doesnt_double_the_header() -> None:
     source = dedent(
         """\
         ---
-        program: yamlfix"""
+        program: yamlfix
+        """
     )
 
     result = fix_code(source)
@@ -66,14 +68,16 @@ def test_fix_code_corrects_indentation_on_lists() -> None:
         ---
         hosts:
         - item1
-        - item2"""
+        - item2
+        """
     )
     fixed_source = dedent(
         """\
         ---
         hosts:
           - item1
-          - item2"""
+          - item2
+        """
     )
 
     result = fix_code(source)
@@ -87,7 +91,8 @@ def test_fix_code_respects_parent_lists() -> None:
         """\
         ---
         - item1
-        - item2"""
+        - item2
+        """
     )
 
     result = fix_code(source)
@@ -101,7 +106,8 @@ def test_fix_code_preserves_comments() -> None:
         """\
         ---
         # Keep comments!
-        program: yamlfix"""
+        program: yamlfix
+        """
     )
 
     result = fix_code(source)
@@ -116,7 +122,8 @@ def test_fix_code_respects_parent_lists_with_comments() -> None:
         ---
         # Comment
         - item1
-        - item2"""
+        - item2
+        """
     )
 
     result = fix_code(source)
@@ -130,7 +137,8 @@ def test_fix_code_preserves_indented_comments() -> None:
         """\
         ---
         - program:
-          # Keep comments!"""
+          # Keep comments!
+        """
     )
 
     result = fix_code(source)
@@ -143,12 +151,14 @@ def test_fix_code_removes_extra_apostrophes() -> None:
     source = dedent(
         """\
         ---
-        title: 'Why we sleep'"""
+        title: 'Why we sleep'
+        """
     )
     fixed_source = dedent(
         """\
         ---
-        title: Why we sleep"""
+        title: Why we sleep
+        """
     )
 
     result = fix_code(source)
@@ -168,14 +178,16 @@ def test_fix_code_converts_non_valid_true_booleans(true_string: str) -> None:
         ---
         True dictionary: {true_string}
         True list:
-          - {true_string}"""
+          - {true_string}
+        """
     )
     fixed_source = dedent(
         """\
         ---
         True dictionary: true
         True list:
-          - true"""
+          - true
+        """
     )
 
     result = fix_code(source)
@@ -195,14 +207,16 @@ def test_fix_code_converts_non_valid_false_booleans(false_string: str) -> None:
         ---
         False dictionary: {false_string}
         False list:
-          - {false_string}"""
+          - {false_string}
+        """
     )
     fixed_source = dedent(
         """\
         ---
         False dictionary: false
         False list:
-          - false"""
+          - false
+        """
     )
 
     result = fix_code(source)
@@ -221,7 +235,8 @@ def test_fix_code_respects_apostrophes_for_truthy_substitutions(
     source = dedent(
         f"""\
         ---
-        title: '{truthy_string}'"""
+        title: '{truthy_string}'
+        """
     )
 
     result = fix_code(source)
@@ -237,13 +252,15 @@ def test_fix_code_adds_space_in_comment() -> None:
         """\
         ---
         #This is a comment
-        project: yamlfix"""
+        project: yamlfix
+        """
     )
     fixed_source = dedent(
         """\
         ---
         # This is a comment
-        project: yamlfix"""
+        project: yamlfix
+        """
     )
 
     result = fix_code(source)
@@ -259,13 +276,15 @@ def test_fix_code_not_add_extra_space_in_comment() -> None:
         """\
         ---
         # This is a comment
-        project: yamlfix"""
+        project: yamlfix
+        """
     )
     fixed_source = dedent(
         """\
         ---
         # This is a comment
-        project: yamlfix"""
+        project: yamlfix
+        """
     )
 
     result = fix_code(source)
@@ -280,12 +299,14 @@ def test_fix_code_add_space_inline_comment() -> None:
     source = dedent(
         """\
         ---
-        project: yamlfix  #This is a comment"""
+        project: yamlfix  #This is a comment
+        """
     )
     fixed_source = dedent(
         """\
         ---
-        project: yamlfix  # This is a comment"""
+        project: yamlfix  # This is a comment
+        """
     )
 
     result = fix_code(source)
@@ -299,7 +320,8 @@ def test_fix_code_respects_url_anchors() -> None:
         """\
         ---
         # https://lyz-code.github.io/yamlfix/#usage
-        foo: bar"""
+        foo: bar
+        """
     )
 
     result = fix_code(source)
@@ -314,12 +336,14 @@ def test_fix_code_add_extra_space_inline_comment() -> None:
     source = dedent(
         """\
         ---
-        project: yamlfix # This is a comment"""
+        project: yamlfix # This is a comment
+        """
     )
     fixed_source = dedent(
         """\
         ---
-        project: yamlfix  # This is a comment"""
+        project: yamlfix  # This is a comment
+        """
     )
 
     result = fix_code(source)
@@ -334,7 +358,8 @@ def test_fix_code_doesnt_change_double_exclamation_marks() -> None:
     source = dedent(
         """\
         ---
-        format: !!python/name:mermaid2.fence_mermaid"""
+        format: !!python/name:mermaid2.fence_mermaid
+        """
     )
 
     result = fix_code(source)
@@ -351,7 +376,8 @@ def test_fix_code_parses_files_with_multiple_documents() -> None:
         ---
         project: yamlfix
         ---
-        project: yamlfix"""
+        project: yamlfix
+        """
     )
 
     result = fix_code(source)
@@ -376,3 +402,26 @@ def test_fix_code_functions_emit_debug_logs(caplog: pytest.LogCaptureFixture) ->
     assert caplog.messages == expected_logs
     for record in caplog.records:
         assert record.levelname == "DEBUG"
+
+
+@pytest.mark.parametrize("whitespace", ["", "\n", "\n\n"])
+def test_fixed_code_has_exactly_one_newline_at_end_of_file(whitespace) -> None:
+    """Files should have exactly one newline at the end to comply with the POSIX
+    standard.
+    """
+    source = dedent(
+        """\
+        ---
+        program: yamlfix"""
+    )
+    source += whitespace
+    fixed_code = dedent(
+        """\
+        ---
+        program: yamlfix
+        """
+    )
+
+    result = fix_code(source)
+
+    assert result == fixed_code


### PR DESCRIPTION
Fixes issue https://github.com/lyz-code/yamlfix/issues/115.

I added a new fixer function to add the newline at the end because I thought it was a simpler and more readable solution than changing all the code in the other fixer functions where the trailing whitespace was removed. The newlines were being removed not only in `_ruamel_yaml_fixer` (through the use of `strip()`) but also every time `splitlines()` is called:

```python
>>> from textwrap import dedent
>>> source = dedent("""\
...     ---
...     program: yaml_fix
...     """
... )
>>> source_lines = source.splitlines()
>>> print(source_lines)
['---', 'program: yaml_fix']
```

Using `splitlines()` with `keepends=True` would also be complicated since it would also keep unwanted whitespace in every line and not just at the end.

Also, I marked it as `fix` in the commit message and PR because it was labeled as a bug, but I think the fix goes a bit further and could be considered a feature, since yamlfix now fixes newlines at end of file for you :thinking: Thoughts?

## Checklist

* [x] Add test cases to all the changes you introduce (and modified existing ones to match the new spec).
* [x] Update the documentation for the changes
