### PR TITLE
fix: update ruyaml version with anchor bug fix

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python-version }}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -76,7 +76,7 @@ linting locally.
     **tl;dr**: use `make format` to fix formatting, `make` to run tests and linting & `make docs`
     to build the docs.
 
-You'll need to have python 3.6, 3.7, or 3.8, virtualenv, git, and make installed.
+You'll need to have python 3.7 or 3.8, virtualenv, git, and make installed.
 
 * Clone your fork and go into the repository directory:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version_files = [
 
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -107,7 +107,7 @@ flake8-use-fstring = [
 flake8-typing-imports = [
   "+*",
   "-TYP001", # guard import by `if False:  # TYPE_CHECKING`: TYPE_CHECKING (not in
-             #   3.5.0, 3.5.1). We don't support Python < 3.6
+             #   3.5.0, 3.5.1). We don't support Python < 3.7
 ]
 flake8-variables-names = ["+*"]
 dlint = ["+*"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -396,7 +396,7 @@ requests==2.26.0
     #   -r docs/requirements.txt
     #   mkdocs-htmlproofer-plugin
     #   safety
-ruyaml==0.20.0
+git+git://github.com/pycontribs/ruyaml@0.90.0.2#egg=ruyaml
     # via -r requirements.txt
 safety==1.10.3
     # via -r requirements-dev.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ distro==1.6.0
     # via ruyaml
 importlib-metadata==4.8.1
     # via click
-ruyaml==0.20.0
+git+git://github.com/pycontribs/ruyaml@0.90.0.2#egg=ruyaml
     # via yamlfix (setup.py)
 typing-extensions==3.10.0.2
     # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -51,5 +51,11 @@ setup(
         [console_scripts]
         yamlfix=yamlfix.entrypoints.cli:cli
     """,
-    install_requires=["click", "ruyaml"],
+    install_requires=[
+        "click",
+        # ruyaml pinned to 0.90.0.2 to include fix of anchors and aliases.
+        # This version is not available in pypi.
+        # See https://github.com/lyz-code/yamlfix/issues/120.
+        "ruyaml @ git+git://github.com/pycontribs/ruyaml@0.90.0.2#egg=ruyaml",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     package_dir={"": "src"},
     package_data={"yamlfix": ["py.typed"]},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
@@ -41,7 +41,6 @@ setup(
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Topic :: Utilities",

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -425,3 +425,36 @@ def test_fixed_code_has_exactly_one_newline_at_end_of_file(whitespace) -> None:
     result = fix_code(source)
 
     assert result == fixed_code
+
+
+def test_anchors_and_aliases_with_duplicate_merge_keys() -> None:
+    """All anchors and aliases should be preserved even with multiple merge keys
+    and merge keys should be formatted as a list in a single line.
+    """
+    source = dedent(
+        """\
+        ---
+        foo: &c
+          a: a
+        bar: &d
+          b: b
+        all:
+          <<: *c
+          <<: *d
+        """
+    )
+    fixed_code = dedent(
+        """\
+        ---
+        foo: &c
+          a: a
+        bar: &d
+          b: b
+        all:
+          <<: [*c, *d]
+        """
+    )
+
+    result = fix_code(source)
+
+    assert result == fixed_code


### PR DESCRIPTION
Fixes https://github.com/lyz-code/yamlfix/issues/120.

The behavior was caused by a bug in previous versions of ruyaml, fixed in [this commit](https://github.com/pycontribs/ruyaml/commit/1be1a708aaeffc55271d9c86ff56a59c14de4556).

I added a test to reproduce the bug reported and it failed. As expected, test passed after updating ruyaml dependency.