### PR TITLE
fix: don't modify Ansible vaults. Closes #135.

### DIFF
--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -57,6 +57,9 @@ def fix_code(source_code: str) -> str:
     Returns:
         Corrected source code.
     """
+    # Leave Ansible vaults unmodified
+    if source_code.startswith("$ANSIBLE_VAULT;"):
+        return source_code
     fixers = [
         _fix_truthy_strings,
         _fix_comments,

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -32,6 +32,20 @@ false_strings = [
 ]
 
 
+def test_fix_code_ignore_ansible_vaults() -> None:
+    """Adds the --- at the beginning of the source."""
+    source = dedent(
+        """\
+        $ANSIBLE_VAULT;1.1;AES256
+        3036303361343731386530393763...
+        """
+    )
+
+    result = fix_code(source)
+
+    assert result == source
+
+
 def test_fix_code_adds_header() -> None:
     """Adds the --- at the beginning of the source."""
     source = "program: yamlfix"


### PR DESCRIPTION
This change ensures Ansible vaults are not inadvertantly modified by yamlfix.

## Checklist

* [X ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
