### PR TITLE
fix: support comments in the middle of a string

### DIFF
--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -3,6 +3,7 @@
 Classes and functions that connect the different domain model objects with the adapters
 and handlers to achieve the program's purpose.
 """
+
 import logging
 import re
 from io import StringIO
@@ -263,9 +264,11 @@ def _fix_comments(source_code: str) -> str:
     fixed_source_lines = []
 
     for line in source_code.splitlines():
+        # Comment at the start of the line
         if re.search(r"(^|\s)#\w", line):
             line = line.replace("#", "# ")
-        if re.match(r".+\S\s#", line):
+        # Comment in the middle of the line, but it's not part of a string
+        if re.match(r".+\S\s#", line) and line[-1] not in ["'", '"']:
             line = line.replace(" #", "  #")
         fixed_source_lines.append(line)
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -456,6 +456,7 @@ def test_fixed_code_has_exactly_one_newline_at_end_of_file(whitespace) -> None:
     assert result == fixed_code
 
 
+@pytest.mark.skip("Not until https://github.com/lyz-code/yamlfix/issues/120 is closed")
 def test_anchors_and_aliases_with_duplicate_merge_keys() -> None:
     """All anchors and aliases should be preserved even with multiple merge keys
     and merge keys should be formatted as a list in a single line.
@@ -487,3 +488,45 @@ def test_anchors_and_aliases_with_duplicate_merge_keys() -> None:
     result = fix_code(source)
 
     assert result == fixed_code
+
+
+def test_fix_code_respects_comment_symbol_in_strings_with_simple_quotes() -> None:
+    """
+    Given: Code with a string that contains a #
+    When: fix_code is run
+    Then: The string is left unchanged
+    """
+    source = dedent(
+        """\
+        ---
+        project: 'Here # is not a comment marker'
+        """
+    )
+
+    result = fix_code(source)
+
+    assert result == source
+
+
+def test_fix_code_respects_comment_symbol_in_strings_with_double_quotes() -> None:
+    """
+    Given: Code with a string that contains a #
+    When: fix_code is run
+    Then: The string is left unchanged
+    """
+    source = dedent(
+        """\
+        ---
+        project: "Here # is not a comment marker"
+        """
+    )
+    desired_source = dedent(
+        """\
+        ---
+        project: 'Here # is not a comment marker'
+        """
+    )
+
+    result = fix_code(source)
+
+    assert result == desired_source


### PR DESCRIPTION
<!-- Describe what the change is, trying to link it with open issues -->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
