### PR TITLE
feat: don't overwrite files if content is not modified. Closes #142.

### DIFF
--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -34,10 +34,13 @@ def fix_files(files: Tuple[TextIOWrapper]) -> Optional[str]:
         if file_wrapper.name == "<stdin>":
             return fixed_source
         else:
-            file_wrapper.seek(0)
-            file_wrapper.write(fixed_source)
-            file_wrapper.truncate()
-            log.debug("Fixed file %s.", file_wrapper.name)
+            if fixed_source != source:
+                file_wrapper.seek(0)
+                file_wrapper.write(fixed_source)
+                file_wrapper.truncate()
+                log.debug("Fixed file %s.", file_wrapper.name)
+            else:
+                log.debug("Left file %s unmodified.", file_wrapper.name)
 
     return None
 


### PR DESCRIPTION
This change prevents yamlfix from overwriting files when their content wasn't fixed by yamlfix. This avoids unnecessary disk I/O.
