### PR TITLE
fix: fix types of pre-commit-hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,6 +5,6 @@
   require_serial: true
   language: python
   language_version: python3
-  types_or: [cython, pyi, python]
+  types: [file, yaml]
   args: []
   minimum_pre_commit_version: 2.9.0


### PR DESCRIPTION
<!-- Describe what the change is, trying to link it with open issues -->

Since it seems a copy-paste mistake from [here](https://github.com/lyz-code/autoimport/blob/d776b6b1c6a76ded1dd2057345f8b7b56321fbb0/.pre-commit-hooks.yaml) or somewhere else, I fixed it to be the same as [yamllint](https://github.com/adrienverge/yamllint/blob/d0392b34ca15fb56061a4edc594ae2dd67b0cff9/.pre-commit-hooks.yaml#L11).

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
