### PR TITLE
for comment only yaml files, preserve the comments

### DIFF
--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -165,6 +165,19 @@ class TestFixCode:
 
         assert result == source
 
+    def test_fix_code_preserves_comment_only_file(self) -> None:
+        """Don't delete comments even if the file is only comments."""
+        source = dedent(
+            """\
+            ---
+            # Keep comments!
+            """
+        )
+
+        result = fix_code(source)
+
+        assert result == source
+        
     def test_fix_code_respects_parent_lists_with_comments(self) -> None:
         """Do not indent lists at the first level even if there is a comment."""
         source = dedent(


### PR DESCRIPTION
If a yaml file contains comments only, preserve the comments (never harm the user's file!)

## Checklist

* [X] Add test cases to all the changes you introduce
* [X] Update the documentation for the changes