### PR TITLE
feat: make yamlfix configurable with sane default values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-added-large-files
@@ -9,19 +9,30 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
   - repo: https://github.com/ambv/black
-    rev: 21.12b0
+    rev: 22.12.0
     hooks:
       - id: black
         language_version: python3.7
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910-1
+    rev: v0.910
     hooks:
       - name: Run mypy static analysis tool
         id: mypy
-        args: [--no-warn-unused-ignores, --ignore-missing-imports]
         files: src
-  - repo: https://github.com/flakehell/flakehell/
-    rev: v.0.9.0
+        additional_dependencies:
+          - pydantic
+        args:
+          - --no-warn-unused-ignores
+          - --ignore-missing-imports
+          # Only in this pre-commit hook, it is necessary to set this argument, it is working as intended in the normal `pdm run mypy` run:
+          # mypy doesn't pick up the pyproject.toml configuration in the pre-commit hook, which already has this option enabled
+          - --allow-untyped-decorators
+          # Only in this pre-commit hook, it is working as intended in the normal `pdm run mypy` run:
+          # mypy doesn't recognize the ConfigSchema type and gives the error
+          # Class cannot subclass "ConfigSchema" (has type "Any")
+          - --allow-subclassing-any
+  - repo: https://github.com/flakeheaven/flakeheaven
+    rev: 0.11.1
     hooks:
-      - name: Run flakehell static analysis tool
-        id: flakehell
+      - name: Run flakeheaven static analysis tool
+        id: flakeheaven

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,10 @@ Imagine we've got the following source code:
 
 ```yaml
 book_library:
-  - title: Why we sleep
-    author: Matthew Walker
-  - title: Harry Potter and the Methods of Rationality
-    author: Eliezer Yudkowsky
+- title: Why we sleep
+  author: Matthew Walker
+- title: Harry Potter and the Methods of Rationality
+  author: Eliezer Yudkowsky
 ```
 
 It has the following errors:
@@ -62,7 +62,7 @@ variable, use `fix_code`:
 
 # Features
 
-yamlfix will do the following changes in your code:
+`yamlfix` will do the following changes in your yaml source code per default:
 
 - Add the header `---` to your file.
 - [Correct truthy strings](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy):
@@ -76,6 +76,287 @@ yamlfix will do the following changes in your code:
 - Split long lines.
 - Respect Jinja2 syntax.
 - Ensure a `\n` exists at the end of the file.
+- Convert short lists to flow-style `list: [item, item]`
+- Convert lists longer than line-width to block-style:
+  ```yaml
+  list:
+    - item
+    - item
+  ```
+
+# Configuration
+
+`yamlfix` uses the `maison` library to find and parse configuration from standard locations, and can additionally be configured through environment variables.
+
+Any configuration found in the [YamlfixConfig class](./reference/#yamlfix.model.YamlfixConfig) can be set through your projects `pyproject.toml`, a custom `toml`-file or through the environment by providing an environment variable like `{yamlfix_env_prefix}_{yamlfix_config_key}`.
+
+Configuration options that are provided through environment variables have higher priority than options provided through configuration files and will override those keys.
+
+All provided [configuration options](#configuration-options), be it through `pyproject.toml`, config-files or env-vars, will be parsed by `pydantic`, so the target value type (str, bool, int, etc.) will be enforced, even if the provided value has the wrong type (for example all env vars in linux systems are strings, but pydantic will parse them to bools/numbers where necessary).
+
+## Auto-Configure through `pyproject.toml`
+
+The `maison` library will automatically pick up your `yamlfix` configuration through your projects `pyproject.toml`. It will look in the section named `tool.yamlfix` and apply the provided [configuration options](#configuration-options). For example:
+
+```toml
+# pyproject.toml
+
+[tool.yamlfix]
+allow_duplicate_keys = true
+line_length = 80
+none_representation = "null"
+```
+
+## Provide config-files
+
+When running `yamlfix` as a standalone cli application it might be desireable to provide a config file containing just the configuration related to `yamlfix`. A cli-argument `-c` (`--config-file`) can be provided multiple times to read configuration values from `toml` formatted files. The rightmost value-files override the value-files preceding them, only trumped by environment variables. No section headers are necessary for these configuration files, as the expected behaviour is, that those files contain only configuration related to `yamlfix`. For example:
+
+```bash
+# run yamlfix with two config files
+yamlfix -c base.toml --config-file environment.toml file.yaml
+```
+
+```toml
+# base.toml
+allow_duplicate_keys = false
+line_length = 100
+```
+
+```toml
+# environment.toml
+allow_duplicate_keys = true
+```
+
+These provided configuration files would result in a merged runtime-configuration of:
+```toml
+# merged configuration
+allow_duplicate_keys = true
+line_length = 100
+```
+
+## Configure environment prefix
+
+Per default `yamlfix`, when run through cli, will read any environment variable that starts with `YAMLFIX_` and apply it to the merged runtime-configuration object. This default value can be overridden with the cli-parameter `--env-prefix`. For example:
+
+```bash
+# set a configuration value with the default prefix
+export YAMLFIX_LINE_LENGTH="300"
+
+# set a configuration value with the custom prefix
+export MY_PREFIX_NONE_REPRESENTATION="~"
+
+# run yamlfix with a custom environment prefix
+yamlfix --env-prefix "MY_PREFIX" file.yaml
+```
+
+These provided arguments and environment variables would result in a merged runtime-configuration of:
+```toml
+# merged configuration
+# default value for line_length stays at: 80
+none_representation = "~"
+```
+
+## Configuration Options
+
+All fields configured in the [YamlfixConfig class](./reference/#yamlfix.model.YamlfixConfig) can be provided through the means mentioned in [Configuration](#configuration). Here are the currently available configuration options with short examples on their impact to provided `yaml`-files.
+
+### Allow Duplicate Keys
+
+Default: `allow_duplicate_keys: bool = True`<br>
+Environment variable override:
+```bash
+export YAMLFIX_ALLOW_DUPLICATE_KEYS="true"
+```
+
+This option enables the [ruyaml duplicate keys check](https://ruyaml.readthedocs.io/en/latest/api.html#duplicate-keys). With this check enabled `yamlfix` will throw an error if the same key is defined more than once in a dict. Before enabling this option, you should be aware, that multiple yaml-anchor merge keys are considered duplicate keys and should be provided as a list instead: https://github.com/pycontribs/ruyaml/issues/43
+
+### Config Path
+
+Default: `config_path: Optional[str] = None`<br>
+Environment variable override:
+```bash
+export YAMLFIX_CONFIG_PATH="/etc/yamlfix/"
+```
+
+Configure the base config-path that `maison` will look for a `pyproject.toml` configuration file. This path is traversed upwards until such a file is found.
+
+### Explicit Document Start
+
+Default: `explicit_start: bool = True`<br>
+Environment variable override:
+```bash
+export YAMLFIX_EXPLICIT_START="true"
+```
+
+Add or remove the explicit document start (`---`) for `yaml`-files. For example:
+
+Set to `true`:
+```yaml
+---
+project_name: yamlfix
+```
+
+Set to `false`:
+```yaml
+project_name: yamlfix
+```
+
+### Flow-Style Sequence (Lists)
+
+Default: `flow_style_sequence: Optional[bool] = True`<br>
+Environment variable override:
+```bash
+export YAMLFIX_FLOW_STYLE_SEQUENCE="true"
+```
+
+Transform sequences (lists) to either flow-style, block-style or leave them as-is. If enabled `yamlfix` will also ensure, that flow-style lists are automatically converted to block-style if the resulting key+list elements would breach the line-length. For example:
+
+Set to `true` (flow-style):
+```yaml
+---
+list: [item, item, item]
+```
+
+Set to `false` (block-style):
+```yaml
+---
+list:
+  - item
+  - item
+  - item
+```
+
+### Indentation
+
+Default:
+`indent_mapping: int = 2`
+`indent_offset: int = 2`
+`indent_sequence: int = 4`
+Environment variable override:
+```bash
+export YAMLFIX_INDENT_MAPPING="2"
+export YAMLFIX_INDENT_OFFSET="2"
+export YAMLFIX_INDENT_SEQUENCE="4"
+```
+
+Provide the `ruyaml` configuration for indentation of mappings (dicts) and sequences (lists) and the indentation offset for elements. See the `ruyaml` configuration documentation: https://ruyaml.readthedocs.io/en/latest/detail.html#indentation-of-block-sequences
+
+### Line Length (Width)
+
+Default: `line_length: int = 80`<br>
+Environment variable override:
+```bash
+export YAMLFIX_LINE_LENGTH="80"
+```
+
+Configure the line-length / width configuration for `ruyaml`. With this configuration long multiline-strings will be wrapped at that point and flow-style lists will be converted to block-style if they are longer than the provided value.
+
+### `None` Representation
+
+Default: `none_representation: str = ""`<br>
+Environment variable override:
+```bash
+export YAMLFIX_LINE_LENGTH=""
+```
+
+In `yaml`-files an absence of a value can be described in multiple canonical ways. This configuration enforces a user-defined representation for `None` values. For example:
+
+Valid `None` representation values are `(empty string)`, `null`, `Null`, `NULL`, `~`.
+
+Provided the source yaml file looks like this:
+```yaml
+none_value1:
+none_value2: null
+none_value3: Null
+none_value4: NULL
+none_value5: ~
+```
+
+The default behaviour (empty string) representation would look like this:
+```yaml
+none_value1:
+none_value2:
+none_value3:
+none_value4:
+none_value5:
+```
+
+With this option set to `none_representation="null"` it would look like this:
+```yaml
+none_value1: null
+none_value2: null
+none_value3: null
+none_value4: null
+none_value5: null
+```
+
+### Quote Basic Values
+
+Default: `quote_basic_values: bool = False`<br>
+Environment variable override:
+```bash
+export YAMLFIX_quote_basic_values="false"
+```
+
+Per default `ruyaml` will quote only values where it is necessary to explicitly define the type of a value. This is the case for numbers and boolean values for example. If your `yaml`-file contains a value of type string that would look like a number, then this value needs to be quoted.
+
+This option allows for quoting of all simple values in mappings (dicts) and sequences (lists) to enable a homogeneous look and feel for string lists / simple key/value mappings. For example:
+
+```yaml
+# option set to false
+stringKey1: abc
+stringKey2: "123"
+stringList: [abc, "123"]
+```
+
+```yaml
+# option set to true
+stringKey1: "abc"
+stringKey2: "123"
+stringList: ["abc", "123"]
+```
+
+### Quote Keys and Basic Values
+
+Default: `quote_keys_and_basic_values: bool = False`<br>
+Environment variable override:
+```bash
+export YAMLFIX_quote_keys_and_basic_values="false"
+```
+
+Similar to the [quote basic values](#quote-basic-values) configuration option, this option, in addition to the values themselves, quotes the keys as well. For example:
+
+```yaml
+# option set to false
+key: value
+list: [item, item]
+```
+
+```yaml
+# option set to true
+"key": "value"
+"list": ["item", "item"]
+```
+
+### Quote Representation
+
+Default: `quote_representation: str = "'"`<br>
+Environment variable override:
+```bash
+export YAMLFIX_quote_representation="'"
+```
+
+Configure which quotation string is used for quoting values. For example:
+
+```yaml
+# Option set to: '
+key: 'value'
+```
+
+```yaml
+# Option set to: "
+key: "value"
+```
 
 # References
 
@@ -91,6 +372,8 @@ maintained for of [ruamel](https://yaml.readthedocs.io/en/latest/) yaml parser.
 
 [Click](https://click.palletsprojects.com/) : Used to create the command line
 interface.
+
+[maison](https://github.com/dbatten5/maison) : Used for finding, reading and parsing the configuration options.
 
 [Pytest](https://docs.pytest.org/en/latest) : Testing framework, enhanced by the
 awesome [pytest-cases](https://smarie.github.io/python-pytest-cases/) library
@@ -124,7 +407,7 @@ issues in Python code.
 # Contributing
 
 For guidance on setting up a development environment, and how to make a
-contribution to *yamlfix*, see
+contribution to `yamlfix`, see
 [Contributing to yamlfix](https://lyz-code.github.io/yamlfix/contributing).
 
 # Donations

--- a/docs/index.md
+++ b/docs/index.md
@@ -162,13 +162,13 @@ All fields configured in the [YamlfixConfig class](./reference/#yamlfix.model.Ya
 
 ### Allow Duplicate Keys
 
-Default: `allow_duplicate_keys: bool = True`<br>
+Default: `allow_duplicate_keys: bool = False`<br>
 Environment variable override:
 ```bash
 export YAMLFIX_ALLOW_DUPLICATE_KEYS="true"
 ```
 
-This option enables the [ruyaml duplicate keys check](https://ruyaml.readthedocs.io/en/latest/api.html#duplicate-keys). With this check enabled `yamlfix` will throw an error if the same key is defined more than once in a dict. Before enabling this option, you should be aware, that multiple yaml-anchor merge keys are considered duplicate keys and should be provided as a list instead: https://github.com/pycontribs/ruyaml/issues/43
+This option toggles the [ruyaml duplicate keys check](https://ruyaml.readthedocs.io/en/latest/api.html#duplicate-keys). With this setting set to `False`, `yamlfix` will throw an error if the same key is defined more than once in a mapping / dictionary. To allow using the same key, set this value to `True`. You might want to enable this option, if you want to use multiple yaml-anchor merge keys, instead of providing them as sequence / list elements - see: https://github.com/pycontribs/ruyaml/issues/43
 
 ### Config Path
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,5 +1,11 @@
-::: yamlfix.services
+::: yamlfix.adapters
+
+::: yamlfix.config
 
 ::: yamlfix.entrypoints
+
+::: yamlfix.model
+
+::: yamlfix.services
 
 ::: yamlfix.version

--- a/pdm.lock
+++ b/pdm.lock
@@ -1356,8 +1356,8 @@ requires_python = ">=3.7"
 summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
-lock_version = "4.0"
-content_hash = "sha256:e3b1b6452267c8b51c7b8b74abeb8adf42ecbc1ce858873fc9e2810f9e212fec"
+lock_version = "4.1"
+content_hash = "sha256:75fb5b771d4613f68e1b9ae4220c5371ff9c5c19d5baf5510265686ec8590fe4"
 
 [metadata.files]
 "argcomplete 1.12.3" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ requires-python = ">=3.7"
 dependencies = [
     "click>=8.0.3",
     "ruyaml>=0.91.0",
+    "maison>=1.4.0",
 ]
 name = "yamlfix"
 description = "A simple opionated yaml formatter that keeps your comments!"
@@ -125,7 +126,6 @@ fixers = [
 ]
 typing = [
     "mypy>=0.910",
-
     "types-click>=7.1.8",
 ]
 dev = [

--- a/src/yamlfix/adapters.py
+++ b/src/yamlfix/adapters.py
@@ -294,17 +294,14 @@ class YamlfixRepresenter(RoundTripRepresenter):
 
         key_length: int = len(str(key_node.value)) + quote_length + separator_length
 
-        if not config.flow_style_sequence_multiline:
-            scalar_length: int = 0
+        scalar_length: int = 0
 
-            for node in seq_node.value:
-                if isinstance(node, ScalarNode):
-                    scalar_length += (
-                        len(str(node.value)) + quote_length + separator_length
-                    )
+        for node in seq_node.value:
+            if isinstance(node, ScalarNode):
+                scalar_length += len(str(node.value)) + quote_length + separator_length
 
-            if key_length + scalar_length + bracket_length > config.line_length:
-                return True
+        if key_length + scalar_length + bracket_length > config.line_length:
+            return True
 
         return False
 

--- a/src/yamlfix/config.py
+++ b/src/yamlfix/config.py
@@ -1,1 +1,42 @@
 """Define the configuration of the main program."""
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from maison.config import ProjectConfig
+
+from yamlfix.model import YamlfixConfig
+
+
+def configure_yamlfix(
+    yamlfix_config: YamlfixConfig,
+    config_files: Optional[List[str]] = None,
+    additional_config: Optional[Dict[str, str]] = None,
+) -> None:
+    """Configure the YamlfixConfig object from .toml/.ini configuration files \
+        and additional config overrides."""
+    config_path: Optional[Path] = None
+
+    if additional_config:
+        config_path_env: Optional[str] = additional_config.get("config_path", None)
+        if config_path_env:
+            config_path = Path(config_path_env)
+
+    config: ProjectConfig = ProjectConfig(
+        config_schema=YamlfixConfig,
+        merge_configs=True,
+        project_name="yamlfix",
+        source_files=config_files,
+        starting_path=config_path,
+    )
+    config_dict: Dict[str, Any] = config.to_dict()
+
+    if additional_config:
+        for override_key, override_val in additional_config.items():
+            config_dict[override_key] = override_val
+
+    config.validate()
+    config_dict = config.to_dict()
+
+    for config_key, config_val in config_dict.items():
+        setattr(yamlfix_config, config_key, config_val)

--- a/src/yamlfix/entrypoints/cli.py
+++ b/src/yamlfix/entrypoints/cli.py
@@ -1,14 +1,17 @@
 """Command line interface definition."""
 
 import logging
+import os
 import sys
-from typing import Tuple
+from typing import Dict, List, Optional, Tuple
 
 import click
 from _io import TextIOWrapper
 
 from yamlfix import services, version
+from yamlfix.config import configure_yamlfix
 from yamlfix.entrypoints import load_logger
+from yamlfix.model import YamlfixConfig
 
 log = logging.getLogger(__name__)
 
@@ -26,13 +29,37 @@ def _format_file_list(files: Tuple[TextIOWrapper]) -> str:
     is_flag=True,
     help="Check if file(s) needs fixing. No files will be written in this case.",
 )
+@click.option(
+    "--config-file",
+    "-c",
+    multiple=True,
+    type=str,
+    help="Path to a custom configuration file.",
+)
+@click.option(
+    "--env-prefix",
+    type=str,
+    default="YAMLFIX",
+    help="Read yamlfix relevant environment variables starting with this prefix.",
+)
 @click.argument("files", type=click.File("r+"), required=True, nargs=-1)
-def cli(files: Tuple[str], verbose: bool, check: bool) -> None:
+def cli(
+    files: Tuple[str],
+    verbose: bool,
+    check: bool,
+    config_file: Optional[List[str]],
+    env_prefix: str,
+) -> None:
     """Corrects the source code of the specified files."""
     load_logger(verbose)
     log.info("%s files:%s", "Checking" if check else "Fixing", _format_file_list(files))
 
-    fixed_code, changed = services.fix_files(files, check)
+    config = YamlfixConfig()
+    configure_yamlfix(
+        config, config_file, _parse_env_vars_as_yamlfix_config(env_prefix.lower())
+    )
+
+    fixed_code, changed = services.fix_files(files, check, config)
 
     if fixed_code is not None:
         print(fixed_code, end="")
@@ -40,6 +67,19 @@ def cli(files: Tuple[str], verbose: bool, check: bool) -> None:
 
     if changed and check:
         sys.exit(1)
+
+
+def _parse_env_vars_as_yamlfix_config(env_prefix: str) -> Dict[str, str]:
+    prefix_length = len(env_prefix) + 1  # prefix with underscore / delimiter (+1)
+    additional_config: Dict[str, str] = {}
+
+    for env_key, env_val in os.environ.items():
+        sanitized_key = env_key.lower()
+
+        if sanitized_key.startswith(env_prefix) and len(sanitized_key) > prefix_length:
+            additional_config[sanitized_key[prefix_length:]] = env_val
+
+    return additional_config
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/yamlfix/model.py
+++ b/src/yamlfix/model.py
@@ -11,8 +11,7 @@ class YamlfixConfig(ConfigSchema):
     allow_duplicate_keys: bool = True
     config_path: Optional[str] = None
     explicit_start: bool = True
-    flow_style_sequence_multiline: bool = False
-    flow_style_sequence: Optional[bool] = None
+    flow_style_sequence: Optional[bool] = True
     indent_mapping: int = 2
     indent_offset: int = 2
     indent_sequence: int = 4

--- a/src/yamlfix/model.py
+++ b/src/yamlfix/model.py
@@ -8,7 +8,7 @@ from maison.schema import ConfigSchema
 class YamlfixConfig(ConfigSchema):
     """Configuration entity for yamlfix."""
 
-    allow_duplicate_keys: bool = True
+    allow_duplicate_keys: bool = False
     config_path: Optional[str] = None
     explicit_start: bool = True
     flow_style_sequence: Optional[bool] = True

--- a/src/yamlfix/model.py
+++ b/src/yamlfix/model.py
@@ -1,0 +1,23 @@
+"""Define program entities like configuration value entities."""
+
+from typing import Optional
+
+from maison.schema import ConfigSchema
+
+
+class YamlfixConfig(ConfigSchema):
+    """Configuration entity for yamlfix."""
+
+    allow_duplicate_keys: bool = True
+    config_path: Optional[str] = None
+    explicit_start: bool = True
+    flow_style_sequence_multiline: bool = False
+    flow_style_sequence: Optional[bool] = None
+    indent_mapping: int = 2
+    indent_offset: int = 2
+    indent_sequence: int = 4
+    line_length: int = 80
+    none_representation: str = ""
+    quote_basic_values: bool = False
+    quote_keys_and_basic_values: bool = False
+    quote_representation: str = "'"

--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -5,13 +5,13 @@ and handlers to achieve the program's purpose.
 """
 
 import logging
-import re
 import warnings
-from io import StringIO
 from typing import List, Optional, Tuple, Union, overload
 
-import ruyaml
 from _io import TextIOWrapper
+
+from yamlfix.adapters import SourceCodeFixer, Yaml
+from yamlfix.model import YamlfixConfig
 
 log = logging.getLogger(__name__)
 
@@ -28,8 +28,17 @@ def fix_files(files: Files, dry_run: Optional[bool]) -> Tuple[Optional[str], boo
     ...
 
 
+@overload
+def fix_files(
+    files: Files, dry_run: Optional[bool], config: Optional[YamlfixConfig]
+) -> Tuple[Optional[str], bool]:
+    ...
+
+
 def fix_files(  # pylint: disable=too-many-branches
-    files: Files, dry_run: Optional[bool] = None
+    files: Files,
+    dry_run: Optional[bool] = None,
+    config: Optional[YamlfixConfig] = None,
 ) -> Union[Optional[str], Tuple[Optional[str], bool]]:  # noqa: TAE002
     """Fix the yaml source code of a list of files.
 
@@ -38,6 +47,7 @@ def fix_files(  # pylint: disable=too-many-branches
     Args:
         files: List of files to fix.
         dry_run: Whether to write changes or not.
+        config: Small set of user provided configuration options for yamlfix.
 
     Returns:
         A tuple with the following items:
@@ -69,7 +79,7 @@ def fix_files(  # pylint: disable=too-many-branches
             file_name = file_.name
 
         log.debug("Fixing file %s...", file_name)
-        fixed_source = fix_code(source)
+        fixed_source = fix_code(source, config)
 
         if fixed_source != source:
             changed = True
@@ -100,7 +110,7 @@ def fix_files(  # pylint: disable=too-many-branches
     return (None, changed)
 
 
-def fix_code(source_code: str) -> str:
+def fix_code(source_code: str, config: Optional[YamlfixConfig] = None) -> str:
     """Fix yaml source code to correct the format.
 
     It corrects these errors:
@@ -112,6 +122,7 @@ def fix_code(source_code: str) -> str:
 
     Args:
         source_code: Source code to be corrected.
+        config: Small set of user provided configuration options for yamlfix.
 
     Returns:
         Corrected source code.
@@ -128,299 +139,9 @@ def fix_code(source_code: str) -> str:
     else:
         shebang = ""
 
-    fixers = [
-        _fix_truthy_strings,
-        _fix_comments,
-        _fix_jinja_variables,
-        _ruamel_yaml_fixer,
-        _restore_truthy_strings,
-        _restore_double_exclamations,
-        _restore_jinja_variables,
-        _fix_top_level_lists,
-        _add_newline_at_end_of_file,
-    ]
-    for fixer in fixers:
-        source_code = fixer(source_code)
+    yaml = Yaml(config=config)
+    fixer = SourceCodeFixer(yaml=yaml, config=config)
+
+    source_code = fixer.fix(source_code=source_code)
 
     return shebang + source_code
-
-
-def _ruamel_yaml_fixer(source_code: str) -> str:
-    """Run Ruamel's yaml fixer.
-
-    Args:
-        source_code: Source code to be corrected.
-
-    Returns:
-        Corrected source code.
-    """
-    log.debug("Running ruamel yaml fixer...")
-    # Configure YAML formatter
-    yaml = ruyaml.main.YAML()
-    yaml.indent(mapping=2, sequence=4, offset=2)
-    yaml.allow_duplicate_keys = True
-    # Start the document with ---
-    # ignore: variable has type None, what can we do, it doesn't have type hints...
-    yaml.explicit_start = True  # type: ignore
-    yaml.width = 80  # type: ignore
-    source_dicts = yaml.load_all(source_code)
-
-    # Return the output to a string
-    string_stream = StringIO()
-    for source_dict in source_dicts:
-        yaml.dump(source_dict, string_stream)
-        source_code = string_stream.getvalue()
-    string_stream.close()
-
-    return source_code.strip()
-
-
-def _fix_top_level_lists(source_code: str) -> str:
-    """Deindent the source with a top level list.
-
-    Documents like the following:
-
-    ```yaml
-    ---
-    # Comment
-    - item 1
-    - item 2
-    ```
-
-    Are wrongly indented by the ruyaml parser:
-
-    ```yaml
-    ---
-    # Comment
-      - item 1
-      - item 2
-    ```
-
-    This function restores the indentation back to the original.
-
-    Args:
-        source_code: Source code to be corrected.
-
-    Returns:
-        Corrected source code.
-    """
-    log.debug("Fixing top level lists...")
-    source_lines = source_code.splitlines()
-    fixed_source_lines: List[str] = []
-    is_top_level_list: Optional[bool] = None
-
-    for line in source_lines:
-
-        # Skip the heading and first empty lines
-        if re.match(r"^(---|#.*|)$", line):
-            fixed_source_lines.append(line)
-            continue
-
-        # Check if the first valid line is an indented list item
-        if re.match(r"\s*- +.*", line) and is_top_level_list is None:
-            is_top_level_list = True
-
-            # Extract the indentation level
-            serialized_line = re.match(r"(?P<indent>\s*)- +(?P<content>.*)", line)
-            if serialized_line is None:  # pragma: no cover
-                raise ValueError(f"Error extracting the indentation of line: {line}")
-            indent = serialized_line.groupdict()["indent"]
-
-            # Remove the indentation from the line
-            fixed_source_lines.append(re.sub(rf"^{indent}(.*)", r"\1", line))
-        elif is_top_level_list:
-            # ruyaml doesn't change the indentation of comments
-            if re.match(r"\s*#.*", line):
-                fixed_source_lines.append(line)
-            else:
-                fixed_source_lines.append(re.sub(rf"^{indent}(.*)", r"\1", line))
-        else:
-            return source_code
-
-    return "\n".join(fixed_source_lines)
-
-
-def _fix_truthy_strings(source_code: str) -> str:
-    """Convert common strings that refer to booleans.
-
-    All caps variations of true, yes and on are transformed to true, while false, no and
-    off are transformed to false.
-
-    Ruyaml understands these strings and converts them to the lower version of the word
-    instead of converting them to true and false.
-
-    [More
-    info](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy)
-
-    Args:
-        source_code: Source code to be corrected.
-
-    Returns:
-        Corrected source code.
-    """
-    log.debug("Fixing truthy strings...")
-    source_lines = source_code.splitlines()
-    fixed_source_lines: List[str] = []
-
-    for line in source_lines:
-        line_contains_true = re.match(
-            r"(?P<pre_boolean_text>.*(:|-) )(true|yes|on)$", line, re.IGNORECASE
-        )
-        line_contains_false = re.match(
-            r"(?P<pre_boolean_text>.*(:|-) )(false|no|off)$", line, re.IGNORECASE
-        )
-
-        if line_contains_true:
-            fixed_source_lines.append(
-                f"{line_contains_true.groupdict()['pre_boolean_text']}true"
-            )
-        elif line_contains_false:
-            fixed_source_lines.append(
-                f"{line_contains_false.groupdict()['pre_boolean_text']}false"
-            )
-        else:
-            fixed_source_lines.append(line)
-
-    return "\n".join(fixed_source_lines)
-
-
-def _restore_truthy_strings(source_code: str) -> str:
-    """Restore truthy strings to strings.
-
-    The Ruyaml parser removes the apostrophes of all the caps variations of the strings
-    'yes', 'on', no and 'off' as it interprets them as booleans.
-
-    As this function is run after _fix_truthy_strings, those strings are meant to be
-    strings. So we're turning them back from booleans to strings.
-
-    Args:
-        source_code: Source code to be corrected.
-
-    Returns:
-        Corrected source code.
-    """
-    log.debug("Restoring truthy strings...")
-    source_lines = source_code.splitlines()
-    fixed_source_lines: List[str] = []
-
-    for line in source_lines:
-        line_contains_valid_truthy_string = re.match(
-            r"(?P<pre_boolean_text>.*(:|-) )(?P<boolean_text>yes|on|no|off)$",
-            line,
-            re.IGNORECASE,
-        )
-        if line_contains_valid_truthy_string:
-            fixed_source_lines.append(
-                f"{line_contains_valid_truthy_string.groupdict()['pre_boolean_text']}"
-                f"'{line_contains_valid_truthy_string.groupdict()['boolean_text']}'"
-            )
-        else:
-            fixed_source_lines.append(line)
-
-    return "\n".join(fixed_source_lines)
-
-
-def _fix_comments(source_code: str) -> str:
-    log.debug("Fixing comments...")
-    fixed_source_lines = []
-
-    for line in source_code.splitlines():
-        # Comment at the start of the line
-        if re.search(r"(^|\s)#\w", line):
-            line = line.replace("#", "# ")
-        # Comment in the middle of the line, but it's not part of a string
-        if re.match(r".+\S\s#", line) and line[-1] not in ["'", '"']:
-            line = line.replace(" #", "  #")
-        fixed_source_lines.append(line)
-
-    return "\n".join(fixed_source_lines)
-
-
-def _restore_double_exclamations(source_code: str) -> str:
-    """Restore the double exclamation marks.
-
-    The Ruyaml parser transforms the !!python statement to !%21python which breaks
-    some programs.
-    """
-    log.debug("Restoring double exclamations...")
-    fixed_source_lines = []
-    double_exclamation = re.compile(r"!%21")
-
-    for line in source_code.splitlines():
-        if double_exclamation.search(line):
-            line = line.replace(r"!%21", "!!")
-        fixed_source_lines.append(line)
-
-    return "\n".join(fixed_source_lines)
-
-
-def _add_newline_at_end_of_file(source_code: str) -> str:
-    return source_code + "\n"
-
-
-def _fix_jinja_variables(source_code: str) -> str:
-    """Remove spaces between jinja variables.
-
-    So that they are not split in many lines by ruyaml
-
-    Args:
-        source_code: Source code to be corrected.
-
-    Returns:
-        Corrected source code.
-    """
-    log.debug("Fixing jinja2 variables...")
-    source_lines = source_code.splitlines()
-    fixed_source_lines: List[str] = []
-
-    for line in source_lines:
-        line_contains_jinja2_variable = re.search(r"{{.*}}", line)
-
-        if line_contains_jinja2_variable:
-            line = _encode_jinja2_line(line)
-
-        fixed_source_lines.append(line)
-
-    return "\n".join(fixed_source_lines)
-
-
-def _encode_jinja2_line(line: str) -> str:
-    """Encode jinja variables so that they are not split.
-
-    Using a special character to join the elements inside the {{ }}, so that they are
-    all taken as the same word, and ruyamel doesn't split them.
-    """
-    new_line = []
-    variable_terms: List[str] = []
-
-    for word in line.split(" "):
-        if re.search("}}", word):
-            variable_terms.append(word)
-            new_line.append("★".join(variable_terms))
-            variable_terms = []
-        elif re.search("{{", word) or len(variable_terms) > 0:
-            variable_terms.append(word)
-        else:
-            new_line.append(word)
-
-    return " ".join(new_line)
-
-
-def _restore_jinja_variables(source_code: str) -> str:
-    """Restore the jinja2 variables to their original state.
-
-    Remove the encoding introduced by _fix_jinja_variables to prevent ruyaml to split
-    the variables.
-    """
-    log.debug("Restoring jinja2 variables...")
-    fixed_source_lines = []
-
-    for line in source_code.splitlines():
-        line_contains_jinja2_variable = re.search(r"{{.*}}", line)
-
-        if line_contains_jinja2_variable:
-            line = line.replace("★", " ")
-
-        fixed_source_lines.append(line)
-
-    return "\n".join(fixed_source_lines)

--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -20,19 +20,19 @@ Files = Union[Tuple[TextIOWrapper], List[str]]
 
 @overload
 def fix_files(files: Files) -> Optional[str]:
-    ...
+    ...  # pragma: no cover
 
 
 @overload
 def fix_files(files: Files, dry_run: Optional[bool]) -> Tuple[Optional[str], bool]:
-    ...
+    ...  # pragma: no cover
 
 
 @overload
 def fix_files(
     files: Files, dry_run: Optional[bool], config: Optional[YamlfixConfig]
 ) -> Tuple[Optional[str], bool]:
-    ...
+    ...  # pragma: no cover
 
 
 def fix_files(  # pylint: disable=too-many-branches

--- a/tests/unit/test_adapter_yaml.py
+++ b/tests/unit/test_adapter_yaml.py
@@ -8,7 +8,13 @@ from ruyaml.constructor import DuplicateKeyError
 from yamlfix.model import YamlfixConfig
 from yamlfix.services import fix_code
 
-none_representations = ["", "null", "Null", "NULL", "~"]
+none_representations = [
+    "",
+    "null",
+    "Null",
+    "NULL",
+    "~",
+]
 
 quote_representations = [
     "'",
@@ -278,8 +284,8 @@ class TestYamlAdapter:
             complex_key:
               complex_key2: {quote}value{quote}
               list:
-                - item1
-                - item2
+                - {quote}item1{quote}
+                - {quote}item2{quote}
               complex_list:
                 - item1
                 - complex_item:

--- a/tests/unit/test_adapter_yaml.py
+++ b/tests/unit/test_adapter_yaml.py
@@ -264,7 +264,7 @@ class TestYamlAdapter:
               complex_list:
                 - item1
                 - complex_item:
-                    key: value
+                    key: 'value?'
             """
         )
         quote = quote_representation
@@ -286,7 +286,7 @@ class TestYamlAdapter:
               complex_list:
                 - item1
                 - complex_item:
-                    key: {quote}value{quote}
+                    key: {quote}value?{quote}
             """
         )
         config = YamlfixConfig()

--- a/tests/unit/test_adapter_yaml.py
+++ b/tests/unit/test_adapter_yaml.py
@@ -1,0 +1,567 @@
+"""Test the Yaml and YamlRoundTrip adapters."""
+
+from textwrap import dedent
+
+import pytest
+from ruyaml.constructor import DuplicateKeyError
+
+from yamlfix.model import YamlfixConfig
+from yamlfix.services import fix_code
+
+none_representations = ["", "null", "Null", "NULL", "~"]
+
+quote_representations = [
+    "'",
+    '"',
+]
+
+
+class TestYamlAdapter:
+    """Test the Yaml and YamlRoundTrip adapters."""
+
+    def test_indentation_config(self) -> None:
+        """Make indentation values configurable."""
+        source = dedent(
+            """\
+            project_name: yamlfix
+            list:
+              - item
+            map:
+              key: value
+            """
+        )
+        fixed_source = dedent(
+            """\
+            ---
+            project_name: yamlfix
+            list:
+                -   item
+            map:
+                key: value
+            """
+        )
+        config = YamlfixConfig()
+        config.indent_offset = 4
+        config.indent_mapping = 4
+        config.indent_sequence = 8
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    def test_dont_allow_duplicate_keys_config(self) -> None:
+        """Test if duplicate keys cause an exception when configured."""
+        source = dedent(
+            """\
+            ---
+            project_name: yamlfix
+            project_name: yumlfax
+            """
+        )
+        config = YamlfixConfig()
+        config.allow_duplicate_keys = False
+
+        with pytest.raises(
+            DuplicateKeyError, match='found duplicate key "project_name"'
+        ):
+            fix_code(source, config)
+
+    def test_dont_generate_explicit_start(self) -> None:
+        """Test if the explicit yaml document start indicator is removed\
+            when configured."""
+        source = dedent(
+            """\
+            ---
+            project_name: yamlfix
+            """
+        )
+        fixed_source = dedent(
+            """\
+            project_name: yamlfix
+            """
+        )
+        config = YamlfixConfig()
+        config.explicit_start = False
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    def test_if_line_length_expands(self) -> None:
+        """Test if configurable line-length expands string value."""
+        source = dedent(
+            """\
+            key: value value value value value value
+              value value value value value value
+              value value value value value value
+              value value value value value value
+              value value value value value value
+              value value value value value value
+            """
+        )
+        fixed_source = dedent(
+            """\
+            ---
+            key: value value value value value value value value value value value value value value value value value
+              value value value value value value value value value value value value value value value value value
+              value value
+            """  # noqa: E501
+        )
+        config = YamlfixConfig()
+        config.line_length = 100
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    def test_if_line_length_contracts(self) -> None:
+        """Test if configurable line-length contracts string value."""
+        source = dedent(
+            """\
+            key: value value value value value value
+              value value value value value value
+              value value value value value value
+              value value value value value value
+              value value value value value value
+              value value value value value value
+            """
+        )
+        fixed_source = dedent(
+            """\
+            ---
+            key: value value value
+              value value value value
+              value value value value
+              value value value value
+              value value value value
+              value value value value
+              value value value value
+              value value value value
+              value value value value
+              value
+            """
+        )
+        config = YamlfixConfig()
+        config.line_length = 20
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    @pytest.mark.parametrize("none_representation", none_representations)
+    def test_none_representation_config(self, none_representation: str) -> None:
+        """Make `none` value representations configurable."""
+        source = dedent(
+            """\
+            none1:
+            none2: null
+            none3: Null
+            none4: NULL
+            none5: ~
+            """
+        )
+        fixed_none_representation = f" {none_representation}"
+        if none_representation == "":
+            fixed_none_representation = ""
+        fixed_source = dedent(
+            f"""\
+            ---
+            none1:{fixed_none_representation}
+            none2:{fixed_none_representation}
+            none3:{fixed_none_representation}
+            none4:{fixed_none_representation}
+            none5:{fixed_none_representation}
+            """
+        )
+        config = YamlfixConfig()
+        config.none_representation = none_representation
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    @pytest.mark.parametrize("quote_representation", quote_representations)
+    def test_quote_all_keys_and_values_config(self, quote_representation: str) -> None:
+        """Quote all keys and values with configurable quote representation."""
+        source = dedent(
+            """\
+            none_key: null
+            bool_key: true
+            int_key: 1
+            str_key1: "value"
+            str_key2: 'value'
+            str_key3: value
+            str_multiline: |
+              value
+              value
+            complex_key:
+              complex_key2: value
+              list:
+                - item1
+                - item2
+              complex_list:
+                - item1
+                - complex_item:
+                    key: value
+            """
+        )
+        quote = quote_representation
+        fixed_source = dedent(
+            f"""\
+            ---
+            {quote}none_key{quote}:
+            {quote}bool_key{quote}: true
+            {quote}int_key{quote}: 1
+            {quote}str_key1{quote}: {quote}value{quote}
+            {quote}str_key2{quote}: {quote}value{quote}
+            {quote}str_key3{quote}: {quote}value{quote}
+            {quote}str_multiline{quote}: |
+              value
+              value
+            {quote}complex_key{quote}:
+              {quote}complex_key2{quote}: {quote}value{quote}
+              {quote}list{quote}:
+                - {quote}item1{quote}
+                - {quote}item2{quote}
+              {quote}complex_list{quote}:
+                - {quote}item1{quote}
+                - {quote}complex_item{quote}:
+                    {quote}key{quote}: {quote}value{quote}
+            """
+        )
+        config = YamlfixConfig()
+        config.quote_representation = quote_representation
+        config.quote_keys_and_basic_values = True
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    @pytest.mark.parametrize("quote_representation", quote_representations)
+    def test_quote_values_config(self, quote_representation: str) -> None:
+        """Quote only scalar values with configurable quote representation."""
+        source = dedent(
+            """\
+            none_key: null
+            bool_key: true
+            int_key: 1
+            str_key1: "value"
+            str_key2: 'value'
+            str_key3: value
+            str_multiline: |
+              value
+              value
+            complex_key:
+              complex_key2: value
+              list:
+                - item1
+                - item2
+              complex_list:
+                - item1
+                - complex_item:
+                    key: value
+            """
+        )
+        quote = quote_representation
+        fixed_source = dedent(
+            f"""\
+            ---
+            none_key:
+            bool_key: true
+            int_key: 1
+            str_key1: {quote}value{quote}
+            str_key2: {quote}value{quote}
+            str_key3: {quote}value{quote}
+            str_multiline: |
+              value
+              value
+            complex_key:
+              complex_key2: {quote}value{quote}
+              list:
+                - item1
+                - item2
+              complex_list:
+                - item1
+                - complex_item:
+                    key: {quote}value{quote}
+            """
+        )
+        config = YamlfixConfig()
+        config.quote_representation = quote_representation
+        config.quote_basic_values = True
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    def test_sequence_flow_style_config(self) -> None:
+        """Make inline list style 'flow-style' configurable."""
+        source = dedent(
+            """\
+            list:
+              - item
+              - item
+            list2: [item, item]
+            """
+        )
+        fixed_source = dedent(
+            """\
+            ---
+            list: [item, item]
+            list2: [item, item]
+            """
+        )
+        config = YamlfixConfig()
+        config.flow_style_sequence = True
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    def test_sequence_block_style_config(self) -> None:
+        """Make multi-line list style 'block-style' configurable."""
+        source = dedent(
+            """\
+            list:
+              - item
+              - item
+            list2: [item, item]
+            """
+        )
+        fixed_source = dedent(
+            """\
+            ---
+            list:
+              - item
+              - item
+            list2:
+              - item
+              - item
+            """
+        )
+        config = YamlfixConfig()
+        config.flow_style_sequence = False
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    def test_sequence_block_style_enforcement_for_lists_with_comments(self) -> None:
+        """Fall back to multi-line list style 'block-style' if list contains comments,\
+            even if flow-style is selected."""
+        source = dedent(
+            """\
+            list:
+              # Comment 1
+              - item
+              # Comment 2
+              - item
+            list2:
+              - item
+              - item
+            """
+        )
+        fixed_source = dedent(
+            """\
+            ---
+            list:
+              # Comment 1
+              - item
+              # Comment 2
+              - item
+            list2: [item, item]
+            """
+        )
+        config = YamlfixConfig()
+        config.flow_style_sequence = True
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    def test_sequence_block_style_enforcement_for_lists_with_non_scalar_values(
+        self,
+    ) -> None:
+        """Fall back to multi-line list style 'block-style' if list contains non-scalar\
+            values, like other lists or dicts, even if flow-style is selected."""
+        source = dedent(
+            """\
+            list:
+              - nested_list:
+                  - item
+              - item
+            list2:
+              - item
+              - nested_dict:
+                  key: value
+            list3:
+              - item
+              - item
+            """
+        )
+        fixed_source = dedent(
+            """\
+            ---
+            list:
+              - nested_list: [item]
+              - item
+            list2:
+              - item
+              - nested_dict:
+                  key: value
+            list3: [item, item]
+            """
+        )
+        config = YamlfixConfig()
+        config.flow_style_sequence = True
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    def test_sequence_block_style_enforcement_for_lists_longer_than_line_length(
+        self,
+    ) -> None:
+        """Fall back to multi-line list style 'block-style' if list would be longer than\
+            line_length and multiline flow-style is not enabled, even if flow-style\
+                is selected."""
+        source = dedent(
+            """\
+            looooooooooooooooooooooooooooooooooooongKey:
+              - item
+            list:
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+            list2:
+              - item
+              - item
+              - item
+            """
+        )
+        fixed_source = dedent(
+            """\
+            ---
+            looooooooooooooooooooooooooooooooooooongKey:
+              - item
+            list:
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+            list2: [item, item, item]
+            """
+        )
+        config = YamlfixConfig()
+        config.line_length = 40
+        config.flow_style_sequence = True
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    def test_sequence_flow_style_multiline_config(self) -> None:
+        """Make inline list style 'flow-style' configurable even for lists, that would\
+            wrap into the next line."""
+        source = dedent(
+            """\
+            looooooooooooooooooooooooooooooooooooongKey:
+              - item
+            list:
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+              - loooooooooooooooooooongItem
+            list2:
+              - item
+              - item
+              - item
+            """
+        )
+        fixed_source = dedent(
+            """\
+            ---
+            looooooooooooooooooooooooooooooooooooongKey: [
+              item]
+            list: [loooooooooooooooooooongItem, loooooooooooooooooooongItem,
+              loooooooooooooooooooongItem, loooooooooooooooooooongItem,
+              loooooooooooooooooooongItem, loooooooooooooooooooongItem]
+            list2: [item, item, item]
+            """
+        )
+        config = YamlfixConfig()
+        config.line_length = 40
+        config.flow_style_sequence = True
+        config.flow_style_sequence_multiline = True
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source
+
+    def test_sequence_flow_style_with_trailing_newlines(self) -> None:
+        """Correct flow-style lists that have trailing newlines.
+
+        Without this fix the following block-style list:
+        ```
+        list:
+          - item
+          - item
+
+
+
+        key: value
+        ```
+
+        is converted to this weird-looking flow-style list:
+        ```
+        list: [item, item
+
+
+
+        ]
+        key: value
+        ```
+
+        instead of
+        ```
+        list: [item, item]
+
+
+
+        key: value
+        ```
+        """
+        source = dedent(
+            """\
+            list:
+              - item
+              - item
+
+
+
+            key: value
+            """
+        )
+        fixed_source = dedent(
+            """\
+            ---
+            list: [item, item]
+
+
+
+            key: value
+            """
+        )
+        config = YamlfixConfig()
+        config.flow_style_sequence = True
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source

--- a/tests/unit/test_adapter_yaml.py
+++ b/tests/unit/test_adapter_yaml.py
@@ -50,6 +50,7 @@ class TestYamlAdapter:
         config.indent_offset = 4
         config.indent_mapping = 4
         config.indent_sequence = 8
+        config.flow_style_sequence = None
 
         result = fix_code(source, config)
 
@@ -226,9 +227,7 @@ class TestYamlAdapter:
               value
             {quote}complex_key{quote}:
               {quote}complex_key2{quote}: {quote}value{quote}
-              {quote}list{quote}:
-                - {quote}item1{quote}
-                - {quote}item2{quote}
+              {quote}list{quote}: [{quote}item1{quote}, {quote}item2{quote}]
               {quote}complex_list{quote}:
                 - {quote}item1{quote}
                 - {quote}complex_item{quote}:
@@ -283,9 +282,7 @@ class TestYamlAdapter:
               value
             complex_key:
               complex_key2: {quote}value{quote}
-              list:
-                - {quote}item1{quote}
-                - {quote}item2{quote}
+              list: [{quote}item1{quote}, {quote}item2{quote}]
               complex_list:
                 - item1
                 - complex_item:
@@ -429,8 +426,7 @@ class TestYamlAdapter:
         self,
     ) -> None:
         """Fall back to multi-line list style 'block-style' if list would be longer than\
-            line_length and multiline flow-style is not enabled, even if flow-style\
-                is selected."""
+            line_length, even if flow-style is selected."""
         source = dedent(
             """\
             looooooooooooooooooooooooooooooooooooongKey:
@@ -466,46 +462,6 @@ class TestYamlAdapter:
         config = YamlfixConfig()
         config.line_length = 40
         config.flow_style_sequence = True
-
-        result = fix_code(source, config)
-
-        assert result == fixed_source
-
-    def test_sequence_flow_style_multiline_config(self) -> None:
-        """Make inline list style 'flow-style' configurable even for lists, that would\
-            wrap into the next line."""
-        source = dedent(
-            """\
-            looooooooooooooooooooooooooooooooooooongKey:
-              - item
-            list:
-              - loooooooooooooooooooongItem
-              - loooooooooooooooooooongItem
-              - loooooooooooooooooooongItem
-              - loooooooooooooooooooongItem
-              - loooooooooooooooooooongItem
-              - loooooooooooooooooooongItem
-            list2:
-              - item
-              - item
-              - item
-            """
-        )
-        fixed_source = dedent(
-            """\
-            ---
-            looooooooooooooooooooooooooooooooooooongKey: [
-              item]
-            list: [loooooooooooooooooooongItem, loooooooooooooooooooongItem,
-              loooooooooooooooooooongItem, loooooooooooooooooooongItem,
-              loooooooooooooooooooongItem, loooooooooooooooooooongItem]
-            list2: [item, item, item]
-            """
-        )
-        config = YamlfixConfig()
-        config.line_length = 40
-        config.flow_style_sequence = True
-        config.flow_style_sequence_multiline = True
 
         result = fix_code(source, config)
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -561,8 +561,10 @@ class TestFixCode:
                 - *certmgr-volumes
             """
         )
+        config = YamlfixConfig()
+        config.allow_duplicate_keys = True
 
-        result = fix_code(source)
+        result = fix_code(source, config)
 
         assert result == desired_source
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 import pytest
 
 from yamlfix import fix_files
+from yamlfix.model import YamlfixConfig
 from yamlfix.services import fix_code
 
 true_strings = [
@@ -144,8 +145,10 @@ class TestFixCode:
               - item2
             """
         )
+        config = YamlfixConfig()
+        config.flow_style_sequence = None
 
-        result = fix_code(source)
+        result = fix_code(source, config)
 
         assert result == fixed_source
 
@@ -265,8 +268,7 @@ class TestFixCode:
             """\
             ---
             True dictionary: true
-            True list:
-              - true
+            True list: [true]
             """
         )
 
@@ -295,8 +297,7 @@ class TestFixCode:
             """\
             ---
             False dictionary: false
-            False list:
-              - false
+            False list: [false]
             """
         )
 
@@ -553,7 +554,11 @@ class TestFixCode:
               cert_data:
 
             volumes:
-              <<: [*node-volumes, *vault-volumes, *mongo-volumes, *certmgr-volumes]
+              <<:
+                - *node-volumes
+                - *vault-volumes
+                - *mongo-volumes
+                - *certmgr-volumes
             """
         )
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -468,6 +468,10 @@ class TestFixCode:
         fix_code("")  # act
 
         expected_logs = [
+            "Setting up ruamel yaml 'quote everything' configuration...",
+            "Setting up ruamel yaml 'sequence flow style' configuration...",
+            "Running ruamel yaml base configuration...",
+            "Running source code fixers...",
             "Fixing truthy strings...",
             "Fixing comments...",
             "Fixing jinja2 variables...",
@@ -476,6 +480,7 @@ class TestFixCode:
             "Restoring double exclamations...",
             "Restoring jinja2 variables...",
             "Fixing top level lists...",
+            "Fixing flow-style lists...",
         ]
         assert caplog.messages == expected_logs
         for record in caplog.records:

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -468,7 +468,7 @@ class TestFixCode:
         fix_code("")  # act
 
         expected_logs = [
-            "Setting up ruamel yaml 'quote everything' configuration...",
+            "Setting up ruamel yaml 'quote simple values' configuration...",
             "Setting up ruamel yaml 'sequence flow style' configuration...",
             "Running ruamel yaml base configuration...",
             "Running source code fixers...",


### PR DESCRIPTION
<!-- Describe what the change is, trying to link it with open issues -->
This fixes #117 and fixes #190 

- make default values, like line_length, explicit_start and indentation configurable
- add configuration option for none-value representation
- add configuration option for quote-style representation
- add configuration option for flow-style / block-style sequences
- add an option to quote every key and value
- add an option to quote only simple values
- add an option to switch between multi-line flow-style and flow-style
  -> block-style conversion if the list doesn't fit the line_length
- implement reading of configuration values from files (with maison)
- implement overriding specific values with prefixed env vars

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
