### PR TITLE
[#193]: Allowing optional number of whitelines before comments

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -190,9 +190,9 @@ export YAMLFIX_COMMENTS_REQUIRE_STARTING_SPACE="true"
 
 This option enforces a space between the comment indicator (`#`) and the first character in the comment. It implements the enforcement of the yamllint rule `rules.comments.require-starting-space` - see: https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.comments
 
-### Comments Optional Number Whitelines From  Content
+### Comment Whitelines
 
-Default: `comments_optional_number_whitelines_from_content: int = 1`<br>
+Default: `comment_whitelines: int = 1`<br>
 Environment variable override:
 ```bash
 export YAMLFIX_COMMENTS_OPTIONAL_NUMBER_WHITELINES_FROM_CONTENT="1"

--- a/docs/index.md
+++ b/docs/index.md
@@ -190,12 +190,12 @@ export YAMLFIX_COMMENTS_REQUIRE_STARTING_SPACE="true"
 
 This option enforces a space between the comment indicator (`#`) and the first character in the comment. It implements the enforcement of the yamllint rule `rules.comments.require-starting-space` - see: https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.comments
 
-### Comment Whitelines
+### Comments Whitelines
 
-Default: `comment_whitelines: int = 1`<br>
+Default: `comments_whitelines: int = 1`<br>
 Environment variable override:
 ```bash
-export YAMLFIX_COMMENTS_OPTIONAL_NUMBER_WHITELINES_FROM_CONTENT="1"
+export YAMLFIX_COMMENTS_WHITELINES="1"
 ```
 
 This option allows to add a specific number of whitelines before a comment that starts at the beginning of a new line

--- a/docs/index.md
+++ b/docs/index.md
@@ -198,7 +198,11 @@ Environment variable override:
 export YAMLFIX_COMMENTS_WHITELINES="1"
 ```
 
-This option allows to add a specific number of whitelines before a comment that starts at the beginning of a new line
+This option allows to add a specific number of consecutive whitelines before a comment.
+
+Before a comment-only line, either:
+  - 0 whiteline is allowed
+  - Exactly `comments_whitelines` whitelines are allowed
 
 ### Config Path
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -190,6 +190,16 @@ export YAMLFIX_COMMENTS_REQUIRE_STARTING_SPACE="true"
 
 This option enforces a space between the comment indicator (`#`) and the first character in the comment. It implements the enforcement of the yamllint rule `rules.comments.require-starting-space` - see: https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.comments
 
+### Comments Optional Number Whitelines From  Content
+
+Default: `comments_optional_number_whitelines_from_content: int = 1`<br>
+Environment variable override:
+```bash
+export YAMLFIX_COMMENTS_OPTIONAL_NUMBER_WHITELINES_FROM_CONTENT="1"
+```
+
+This option allows to add a specific number of whitelines before a comment that starts at the beginning of a new line
+
 ### Config Path
 
 Default: `config_path: Optional[str] = None`<br>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,6 +305,7 @@ pylint = [
             # though they are not used in the function directly, they are used to
             # configure the test.
   "-R0904", # Too many public methods (25/20) (too-many-public-methods)
+  "-C0302", # Allows module to have unlimited number of lines.
 ]
 
 [tool.flakeheaven.exceptions."tests/factories.py"]

--- a/src/yamlfix/adapters.py
+++ b/src/yamlfix/adapters.py
@@ -611,7 +611,7 @@ class SourceCodeFixer:
         """Fixes number of consecutive whitelines.
 
         Before a comment-only line, either:
-          - 0 whitelines are allowed
+          - 0 whiteline is allowed
           - Exactly `self.config.comments_whitelines` whitelines are allowed
 
         This method removes extraneous whitelines that are not immediately followed by

--- a/src/yamlfix/adapters.py
+++ b/src/yamlfix/adapters.py
@@ -362,25 +362,6 @@ class SourceCodeFixer:
 
         return source_code
 
-    @staticmethod
-    def _remove_extra_whitelines(match: Match[str]) -> str:
-        """Removes extra whitelines.
-
-        Method used by `SourceCodeFixer._fix_whitelines()` to remove extra whitelines
-        when whitelines are not followed by a comment.
-
-        Args:
-            match: The matched expression by `re`
-
-        Returns:
-            A single new line character followed by the last character of the matched
-            string
-        """
-        pattern_str = match.group()
-        adjusted_pattern_str = "\n" + pattern_str[-1]
-
-        return adjusted_pattern_str
-
     def _ruamel_yaml_fixer(self, source_code: str) -> str:
         """Run Ruamel's yaml fixer.
 
@@ -661,6 +642,25 @@ class SourceCodeFixer:
         )
 
         return source_code
+
+    @staticmethod
+    def _remove_extra_whitelines(match: Match[str]) -> str:
+        """Removes extra whitelines.
+
+        Method used by `SourceCodeFixer._fix_whitelines()` to remove extra whitelines
+        when whitelines are not followed by a comment.
+
+        Args:
+            match: The matched expression by `re`
+
+        Returns:
+            A single new line character followed by the last character of the matched
+            string
+        """
+        pattern_str = match.group()
+        adjusted_pattern_str = "\n" + pattern_str[-1]
+
+        return adjusted_pattern_str
 
     @staticmethod
     def _restore_double_exclamations(source_code: str) -> str:

--- a/src/yamlfix/adapters.py
+++ b/src/yamlfix/adapters.py
@@ -612,7 +612,7 @@ class SourceCodeFixer:
 
         Before a comment-only line, either:
           - 0 whitelines are allowed
-          - Exactly `self.config.comment_whitelines` whitelines are allowed
+          - Exactly `self.config.comments_whitelines` whitelines are allowed
 
         This method removes extraneous whitelines that are not immediately followed by
         a comment.
@@ -624,7 +624,7 @@ class SourceCodeFixer:
             Source code with appropriate whitelines standards.
         """
         config = self.config
-        n_whitelines_from_content = config.comment_whitelines
+        n_whitelines_from_content = config.comments_whitelines
 
         desired_whitelines_with_comments = "\n" * (n_whitelines_from_content + 1) + "#"
         re_whitelines_with_comments = "\n\n+[#]"

--- a/src/yamlfix/adapters.py
+++ b/src/yamlfix/adapters.py
@@ -631,8 +631,7 @@ class SourceCodeFixer:
 
         Before a comment-only line, either:
           - 0 whitelines are allowed
-          - Exactly `self.config.comments_optional_number_whitelines_from_content`
-            whitelines are allowed
+          - Exactly `self.config.comment_whitelines` whitelines are allowed
 
         This method removes extraneous whitelines that are not immediately followed by
         a comment.
@@ -646,9 +645,7 @@ class SourceCodeFixer:
             Source code with appropriate whitelines standards.
         """
         config = self.config
-        n_whitelines_from_content = (
-            config.comments_optional_number_whitelines_from_content
-        )
+        n_whitelines_from_content = config.comment_whitelines
 
         desired_whitelines_with_comments = "\n" * (n_whitelines_from_content + 1) + "#"
         re_whitelines_with_comments = "\n\n+[#]"

--- a/src/yamlfix/adapters.py
+++ b/src/yamlfix/adapters.py
@@ -363,10 +363,11 @@ class SourceCodeFixer:
         return source_code
 
     @staticmethod
-    def _remove_extra_whitelines(match: re.Match) -> str:
-        """
-        Method used by `SourceCodeFixer._fix_whitelines()` to remove extra
-        whitelines when whitelines are not followed by a comment.
+    def _remove_extra_whitelines(match: re.Match[str]) -> str:
+        """Removes extra whitelines.
+
+        Method used by `SourceCodeFixer._fix_whitelines()` to remove extra whitelines
+        when whitelines are not followed by a comment.
 
         Args:
             match: The matched expression by `re`
@@ -375,11 +376,10 @@ class SourceCodeFixer:
             A single new line character followed by the last character of the matched
             string
         """
+        pattern_str = match.group()
+        adjusted_pattern_str = "\n" + pattern_str[-1]
 
-        s = match.group()
-        modified_s = "\n" + s[-1]
-
-        return modified_s
+        return adjusted_pattern_str
 
     def _ruamel_yaml_fixer(self, source_code: str) -> str:
         """Run Ruamel's yaml fixer.
@@ -627,14 +627,17 @@ class SourceCodeFixer:
         return "\n".join(fixed_source_lines)
 
     def _fix_whitelines(self, source_code: str) -> str:
-        """Removes extra whitelines before a comment-only line, otherwise removes every
-        whitelines.
+        r"""Fixes number of consecutive whitelines.
 
-        The number of allowed whitelines before a comment is controlled by
-        `YamlfixConfig.comments_optional_number_whitelines_from_content`.
+        Before a comment-only line, either:
+          - 0 whitelines are allowed
+          - Exactly `self.config.comments_optional_number_whitelines_from_content`
+            whitelines are allowed
 
-        This method assumes that `source_code` had been standardized and that every new
-        lines is denoted by "\n"
+        This method removes extraneous whitelines that are not immediately followed by
+        a comment.
+
+        This method assumes that "\n" denotes a newline
 
         Args:
             self: Source code to be corrected.

--- a/src/yamlfix/adapters.py
+++ b/src/yamlfix/adapters.py
@@ -648,7 +648,7 @@ class SourceCodeFixer:
         )
 
         desired_whitelines_with_comments = "\n" * (n_whitelines_from_content + 1) + "#"
-        re_whitelines_with_comments = "\n" * (n_whitelines_from_content + 2) + "+#"
+        re_whitelines_with_comments = "\n\n+[#]"
         re_whitelines_with_no_comments = "\n\n+[^#\n]"
 
         source_code = re.sub(

--- a/src/yamlfix/adapters.py
+++ b/src/yamlfix/adapters.py
@@ -3,7 +3,7 @@
 import logging
 import re
 from io import StringIO
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Match, Optional, Tuple
 
 from ruyaml.main import YAML
 from ruyaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
@@ -363,7 +363,7 @@ class SourceCodeFixer:
         return source_code
 
     @staticmethod
-    def _remove_extra_whitelines(match: re.Match[str]) -> str:
+    def _remove_extra_whitelines(match: Match[str]) -> str:
         """Removes extra whitelines.
 
         Method used by `SourceCodeFixer._fix_whitelines()` to remove extra whitelines

--- a/src/yamlfix/adapters.py
+++ b/src/yamlfix/adapters.py
@@ -627,7 +627,7 @@ class SourceCodeFixer:
         return "\n".join(fixed_source_lines)
 
     def _fix_whitelines(self, source_code: str) -> str:
-        r"""Fixes number of consecutive whitelines.
+        """Fixes number of consecutive whitelines.
 
         Before a comment-only line, either:
           - 0 whitelines are allowed
@@ -635,8 +635,6 @@ class SourceCodeFixer:
 
         This method removes extraneous whitelines that are not immediately followed by
         a comment.
-
-        This method assumes that "\n" denotes a newline
 
         Args:
             self: Source code to be corrected.

--- a/src/yamlfix/model.py
+++ b/src/yamlfix/model.py
@@ -19,7 +19,7 @@ class YamlfixConfig(ConfigSchema):
     allow_duplicate_keys: bool = False
     comments_min_spaces_from_content: int = 2
     comments_require_starting_space: bool = True
-    comments_optional_number_whitelines_from_content: int = 1
+    comment_whitelines: int = 1
     config_path: Optional[str] = None
     explicit_start: bool = True
     indent_mapping: int = 2

--- a/src/yamlfix/model.py
+++ b/src/yamlfix/model.py
@@ -19,7 +19,7 @@ class YamlfixConfig(ConfigSchema):
     allow_duplicate_keys: bool = False
     comments_min_spaces_from_content: int = 2
     comments_require_starting_space: bool = True
-    comment_whitelines: int = 1
+    comments_whitelines: int = 1
     config_path: Optional[str] = None
     explicit_start: bool = True
     indent_mapping: int = 2

--- a/src/yamlfix/model.py
+++ b/src/yamlfix/model.py
@@ -19,6 +19,7 @@ class YamlfixConfig(ConfigSchema):
     allow_duplicate_keys: bool = False
     comments_min_spaces_from_content: int = 2
     comments_require_starting_space: bool = True
+    comments_optional_number_whitelines_from_content: int = 1
     config_path: Optional[str] = None
     explicit_start: bool = True
     indent_mapping: int = 2

--- a/tests/unit/test_adapter_yaml.py
+++ b/tests/unit/test_adapter_yaml.py
@@ -568,9 +568,6 @@ class TestYamlAdapter:
             """\
             ---
             list: [item, item]
-
-
-
             key: value
             """
         )

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -704,7 +704,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                None,
+                YamlfixConfig(comments_whitelines=1),
                 dedent(
                     """\
                     ---
@@ -744,7 +744,7 @@ class TestFixCode:
                     key: value  # Comment: desired: No lines between `list` and `key`
                     """
                 ),
-                None,
+                YamlfixConfig(comments_whitelines=1),
                 dedent(
                     """\
                     ---
@@ -784,7 +784,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                None,
+                YamlfixConfig(comments_whitelines=1),
                 dedent(
                     """\
                     ---
@@ -873,7 +873,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                None,
+                YamlfixConfig(comments_whitelines=1),
                 dedent(
                     """\
                     ---
@@ -922,31 +922,6 @@ class TestFixCode:
                     """
                 ),
                 YamlfixConfig(comments_whitelines=2),
-                dedent(
-                    """\
-                    ---
-                    list:
-                      - item
-                      # Comment: desired: 0 new lines before this comment
-                      - item
-                    key: value
-                    """
-                ),
-            ),
-            (
-                dedent(
-                    """\
-                    ---
-                    list:
-                      - item
-
-                      # Comment: desired: 0 new lines before this comment
-                      - item
-
-                    key: value
-                    """
-                ),
-                None,
                 dedent(
                     """\
                     ---

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -526,16 +526,12 @@ class TestFixCode:
             ---
             x-node-volumes: &node-volumes
               node3_data:
-
             x-vault-volumes: &vault-volumes
               vault_data:
-
             x-mongo-volumes: &mongo-volumes
               mongo_data:
-
             x-certmgr-volumes: &certmgr-volumes
               cert_data:
-
             volumes:
               <<: *node-volumes
               <<: *vault-volumes

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -724,7 +724,7 @@ class TestFixCode:
                     key: value  # Comment: desired: No lines between `list` and `key`
                     """
                 ),
-                YamlfixConfig(comment_whitelines=0),
+                YamlfixConfig(comments_whitelines=0),
                 dedent(
                     """\
                     ---
@@ -764,7 +764,7 @@ class TestFixCode:
                     key: value  # Comment: desired: No lines between `list` and `key`
                     """
                 ),
-                YamlfixConfig(comment_whitelines=2),
+                YamlfixConfig(comments_whitelines=2),
                 dedent(
                     """\
                     ---
@@ -806,7 +806,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comment_whitelines=0),
+                YamlfixConfig(comments_whitelines=0),
                 dedent(
                     """\
                     ---
@@ -827,7 +827,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comment_whitelines=2),
+                YamlfixConfig(comments_whitelines=2),
                 dedent(
                     """\
                     ---
@@ -849,7 +849,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comment_whitelines=2),
+                YamlfixConfig(comments_whitelines=2),
                 dedent(
                     """\
                     ---
@@ -897,7 +897,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comment_whitelines=0),
+                YamlfixConfig(comments_whitelines=0),
                 dedent(
                     """\
                     ---
@@ -921,7 +921,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comment_whitelines=2),
+                YamlfixConfig(comments_whitelines=2),
                 dedent(
                     """\
                     ---
@@ -971,7 +971,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comment_whitelines=1),
+                YamlfixConfig(comments_whitelines=1),
                 dedent(
                     """\
                     ---
@@ -996,7 +996,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comment_whitelines=2),
+                YamlfixConfig(comments_whitelines=2),
                 dedent(
                     """\
                     ---

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -548,16 +548,12 @@ class TestFixCode:
             ---
             x-node-volumes: &node-volumes
               node3_data:
-
             x-vault-volumes: &vault-volumes
               vault_data:
-
             x-mongo-volumes: &mongo-volumes
               mongo_data:
-
             x-certmgr-volumes: &certmgr-volumes
               cert_data:
-
             volumes:
               <<:
                 - *node-volumes

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -700,6 +700,28 @@ class TestFixCode:
                     list: [item, item]
 
 
+                    # Comment: desired: 1 line (default) before this comment
+                    key: value
+                    """
+                ),
+                None,
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+
+                    # Comment: desired: 1 line (default) before this comment
+                    key: value
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+
+
 
                     key: value
                     """
@@ -780,7 +802,7 @@ class TestFixCode:
                     list: [item, item]
 
 
-                    # Comment: desired: 1 line (default) before this comment
+                    # Comment: desired: 1 line before this comment
                     key: value
                     """
                 ),
@@ -790,7 +812,7 @@ class TestFixCode:
                     ---
                     list: [item, item]
 
-                    # Comment: desired: 1 line (default) before this comment
+                    # Comment: desired: 1 line before this comment
                     key: value
                     """
                 ),

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -843,6 +843,28 @@ class TestFixCode:
                 dedent(
                     """\
                     ---
+                    list: [item, item]
+
+                    # Comment: desired: 2 lines before this comment
+                    key: value
+                    """
+                ),
+                YamlfixConfig(comments_optional_number_whitelines_from_content=2),
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+
+
+                    # Comment: desired: 2 lines before this comment
+                    key: value
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
                     list:
                       - item
                       # Comment: desired: 0 new lines before this comment

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -3,6 +3,7 @@
 import logging
 from pathlib import Path
 from textwrap import dedent
+from typing import Optional
 
 import pytest
 
@@ -696,3 +697,319 @@ class TestFixCode:
         result = fix_code(source)
 
         assert result == source
+
+    @pytest.mark.parametrize(
+        "source,config,desired_source",
+        [
+            (
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+
+
+
+                    key: value
+                    """
+                ),
+                None,
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+                    key: value
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+
+
+
+                    key: value  # Comment: desired: No lines between `list` and `key`
+                    """
+                ),
+                YamlfixConfig(comments_optional_number_whitelines_from_content=0),
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+                    key: value  # Comment: desired: No lines between `list` and `key`
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+
+
+
+                    key: value  # Comment: desired: No lines between `list` and `key`
+                    """
+                ),
+                None,
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+                    key: value  # Comment: desired: No lines between `list` and `key`
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+
+
+
+                    key: value  # Comment: desired: No lines between `list` and `key`
+                    """
+                ),
+                YamlfixConfig(comments_optional_number_whitelines_from_content=2),
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+                    key: value  # Comment: desired: No lines between `list` and `key`
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+
+
+                    # Comment: desired: 1 line (default) before this comment
+                    key: value
+                    """
+                ),
+                None,
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+
+                    # Comment: desired: 1 line (default) before this comment
+                    key: value
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+
+
+                    # Comment: desired: 0 line before this comment
+                    key: value
+                    """
+                ),
+                YamlfixConfig(comments_optional_number_whitelines_from_content=0),
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+                    # Comment: desired: 0 line before this comment
+                    key: value
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+
+
+                    # Comment: desired: 2 lines before this comment
+                    key: value
+                    """
+                ),
+                YamlfixConfig(comments_optional_number_whitelines_from_content=2),
+                dedent(
+                    """\
+                    ---
+                    list: [item, item]
+
+
+                    # Comment: desired: 2 lines before this comment
+                    key: value
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list:
+                      - item
+                      # Comment: desired: 0 new lines before this comment
+                      - item
+
+                    key: value
+                    """
+                ),
+                None,
+                dedent(
+                    """\
+                    ---
+                    list:
+                      - item
+                      # Comment: desired: 0 new lines before this comment
+                      - item
+                    key: value
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list:
+                      - item
+                      # Comment: desired: 0 new lines before this comment
+                      - item
+
+                    key: value
+                    """
+                ),
+                YamlfixConfig(comments_optional_number_whitelines_from_content=0),
+                dedent(
+                    """\
+                    ---
+                    list:
+                      - item
+                      # Comment: desired: 0 new lines before this comment
+                      - item
+                    key: value
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list:
+                      - item
+                      # Comment: desired: 0 new lines before this comment
+                      - item
+
+                    key: value
+                    """
+                ),
+                YamlfixConfig(comments_optional_number_whitelines_from_content=2),
+                dedent(
+                    """\
+                    ---
+                    list:
+                      - item
+                      # Comment: desired: 0 new lines before this comment
+                      - item
+                    key: value
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list:
+                      - item
+
+                      # Comment: desired: 0 new lines before this comment
+                      - item
+
+                    key: value
+                    """
+                ),
+                None,
+                dedent(
+                    """\
+                    ---
+                    list:
+                      - item
+                      # Comment: desired: 0 new lines before this comment
+                      - item
+                    key: value
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list:
+                      - item
+
+                      # Comment: desired: 0 new lines before this comment
+                      - item
+
+                    key: value
+                    """
+                ),
+                YamlfixConfig(comments_optional_number_whitelines_from_content=1),
+                dedent(
+                    """\
+                    ---
+                    list:
+                      - item
+                      # Comment: desired: 0 new lines before this comment
+                      - item
+                    key: value
+                    """
+                ),
+            ),
+            (
+                dedent(
+                    """\
+                    ---
+                    list:
+                      - item
+
+                      # Comment: desired: 0 new lines before this comment
+                      - item
+
+                    key: value
+                    """
+                ),
+                YamlfixConfig(comments_optional_number_whitelines_from_content=2),
+                dedent(
+                    """\
+                    ---
+                    list:
+                      - item
+                      # Comment: desired: 0 new lines before this comment
+                      - item
+                    key: value
+                    """
+                ),
+            ),
+        ],
+    )
+    def test_fix_code_fix_whitelines(
+        self,
+        source: str,
+        config: Optional[YamlfixConfig],
+        desired_source: str,
+    ) -> None:
+        """
+        Given: Code with extra whitelines
+        When: fix_code is run
+        Then: The string has extra whitelines removed
+        """
+        source = source
+        desired_source = desired_source
+
+        result = fix_code(source_code=source, config=config)
+
+        assert result == desired_source

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -691,7 +691,7 @@ class TestFixCode:
         assert result == source
 
     @pytest.mark.parametrize(
-        "source,config,desired_source",
+        ("source", "config", "desired_source"),
         [
             (
                 dedent(
@@ -1021,9 +1021,6 @@ class TestFixCode:
         When: fix_code is run
         Then: The string has extra whitelines removed
         """
-        source = source
-        desired_source = desired_source
-
         result = fix_code(source_code=source, config=config)
 
         assert result == desired_source

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -724,7 +724,7 @@ class TestFixCode:
                     key: value  # Comment: desired: No lines between `list` and `key`
                     """
                 ),
-                YamlfixConfig(comments_optional_number_whitelines_from_content=0),
+                YamlfixConfig(comment_whitelines=0),
                 dedent(
                     """\
                     ---
@@ -764,7 +764,7 @@ class TestFixCode:
                     key: value  # Comment: desired: No lines between `list` and `key`
                     """
                 ),
-                YamlfixConfig(comments_optional_number_whitelines_from_content=2),
+                YamlfixConfig(comment_whitelines=2),
                 dedent(
                     """\
                     ---
@@ -806,7 +806,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comments_optional_number_whitelines_from_content=0),
+                YamlfixConfig(comment_whitelines=0),
                 dedent(
                     """\
                     ---
@@ -827,7 +827,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comments_optional_number_whitelines_from_content=2),
+                YamlfixConfig(comment_whitelines=2),
                 dedent(
                     """\
                     ---
@@ -849,7 +849,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comments_optional_number_whitelines_from_content=2),
+                YamlfixConfig(comment_whitelines=2),
                 dedent(
                     """\
                     ---
@@ -897,7 +897,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comments_optional_number_whitelines_from_content=0),
+                YamlfixConfig(comment_whitelines=0),
                 dedent(
                     """\
                     ---
@@ -921,7 +921,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comments_optional_number_whitelines_from_content=2),
+                YamlfixConfig(comment_whitelines=2),
                 dedent(
                     """\
                     ---
@@ -971,7 +971,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comments_optional_number_whitelines_from_content=1),
+                YamlfixConfig(comment_whitelines=1),
                 dedent(
                     """\
                     ---
@@ -996,7 +996,7 @@ class TestFixCode:
                     key: value
                     """
                 ),
-                YamlfixConfig(comments_optional_number_whitelines_from_content=2),
+                YamlfixConfig(comment_whitelines=2),
                 dedent(
                     """\
                     ---


### PR DESCRIPTION
## Related issue
Resolves #193 -- Remove extra whitelines

## Checklist

* [x] Introduce new parameter `comments_optional_number_whitelines_from_content` in `yamlfix.model.YamlfixConfig`
* [x] Adding two methods used for removing extraneous whitelines:
  * [SourceCodeFixer._fix_whitelines()](https://github.com/lyz-code/yamlfix/blob/024abb478ab0edff6986d290ea7502c7c400ee11/src/yamlfix/adapters.py#L629): Used to return the yaml following the appropriate whitelines standards
  * [SourceCodeFixer._removes_extra_whitelines()](https://github.com/lyz-code/yamlfix/blob/024abb478ab0edff6986d290ea7502c7c400ee11/src/yamlfix/adapters.py#L366): Used to return a single new line character followed by the last character of a matched string
* [x] Add test cases to method `yamlfix.adapters.SourceCodeFixer._fix_whitelines()`
* [x] Add test cases to method `yamlfix.adapters.SourceCodeFixer._removes_extra_whitelines()`
* [x] Adjusting existing test cases
* [x] Update the documentation for the changes

## Introduced standards
* A line that that includes only a comment can have either:
  * 0 preceding whiteline
  * `comments_optional_number_whitelines_from_content` whiteline(s)

For example, if `comments_optional_number_whitelines_from_content==2` these `YaML` are valid:
```
key1: value1
# First comment
key2: value2
```

```
key1: value1


# First comment
key2: value2
```

Similarly, this one would be invalid:
```
key1: value1

# First comment
key2: value2
```
