### PR TITLE
[#210]: Allow whitelines followed by indented comment

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -198,11 +198,14 @@ Environment variable override:
 export YAMLFIX_COMMENTS_WHITELINES="1"
 ```
 
-This option allows to add a specific number of consecutive whitelines before a comment.
+This option allows to add a specific number of consecutive whitelines before a comment-only line.
+
+A comment-only line is defined as a line that starts with a comment or with an indented comment.
 
 Before a comment-only line, either:
-  - 0 whiteline is allowed
-  - Exactly `comments_whitelines` whitelines are allowed
+
+- 0 whiteline is allowed
+- Exactly `comments_whitelines` whitelines are allowed
 
 ### Config Path
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -889,7 +889,7 @@ class TestFixCode:
                     ---
                     list:
                       - item
-                      # Comment: desired: 0 new lines before this comment
+                      # Comment: desired: 0 new line before this comment
                       - item
 
                     key: value
@@ -901,7 +901,7 @@ class TestFixCode:
                     ---
                     list:
                       - item
-                      # Comment: desired: 0 new lines before this comment
+                      # Comment: desired: 0 new line before this comment
                       - item
                     key: value
                     """
@@ -913,7 +913,7 @@ class TestFixCode:
                     ---
                     list:
                       - item
-                      # Comment: desired: 0 new lines before this comment
+                      # Comment: desired: 0 new line before this comment
                       - item
 
                     key: value
@@ -925,7 +925,7 @@ class TestFixCode:
                     ---
                     list:
                       - item
-                      # Comment: desired: 0 new lines before this comment
+                      # Comment: desired: 0 new line before this comment
                       - item
                     key: value
                     """
@@ -937,7 +937,7 @@ class TestFixCode:
                     ---
                     list:
                       - item
-                      # Comment: desired: 0 new lines before this comment
+                      # Comment: desired: 0 new line before this comment
                       - item
 
                     key: value
@@ -949,7 +949,7 @@ class TestFixCode:
                     ---
                     list:
                       - item
-                      # Comment: desired: 0 new lines before this comment
+                      # Comment: desired: 0 new line before this comment
                       - item
                     key: value
                     """
@@ -962,7 +962,7 @@ class TestFixCode:
                     list:
                       - item
 
-                      # Comment: desired: 0 new lines before this comment
+                      # Comment: desired: 1 new line before this comment
                       - item
 
                     key: value
@@ -974,7 +974,8 @@ class TestFixCode:
                     ---
                     list:
                       - item
-                      # Comment: desired: 0 new lines before this comment
+
+                      # Comment: desired: 1 new line before this comment
                       - item
                     key: value
                     """
@@ -987,7 +988,7 @@ class TestFixCode:
                     list:
                       - item
 
-                      # Comment: desired: 0 new lines before this comment
+                      # Comment: desired: 2 new lines before this comment
                       - item
 
                     key: value
@@ -999,7 +1000,9 @@ class TestFixCode:
                     ---
                     list:
                       - item
-                      # Comment: desired: 0 new lines before this comment
+
+
+                      # Comment: desired: 2 new lines before this comment
                       - item
                     key: value
                     """


### PR DESCRIPTION
Resolves #210 -- Allow whitelines on comments that are not on the first level of indentation

## Checklist

* [x] Supporting indented comments by the [comments_whitelines parameter](https://github.com/lyz-code/yamlfix/blob/cc00a6470ddfc655a66f5b0dcf6685732e010655/docs/index.md?plain=1#L193-L216)
* [x] Adding unit-tests for indented comments preceded by whitelines
* [x] Updating the documentation for the changes

## Explaining the regexes
`re_whitelines_with_comments = "\n\n+[\t ]{0,}[#]"`:
* `\n\n+`: Match 2+ newline (i.e. 1+ whiteline)
* `[\t ]{0,}`: Match between `0` and `unlimited` number of `tab` or `space`
* `[#]`: Match a `#`, the first character of a comment

`re_whitelines_with_no_comments = "\n\n+[\t ]{0,}[^#\n\t ]"`:
* `\n\n+`: Match 2+ newline (i.e. 1+ whiteline)
* `[\t ]{0,}`: Match between `0` and `unlimited` number of `tab` or `space`
* `[^#\n\t ]`: Match any character but `#`, `tab` or `space`

