### PR TITLE
feat(services.py): Change behaviour to only list changed files by default

### DIFF
--- a/src/yamlfix/entrypoints/__init__.py
+++ b/src/yamlfix/entrypoints/__init__.py
@@ -6,6 +6,21 @@ Functions:
 
 import logging
 import sys
+from enum import Enum
+
+
+class ANSIFGColorCodes(Enum):
+    """ANSI escape codes for colored output."""
+
+    BLACK = 30
+    RED = 31
+    GREEN = 32
+    YELLOW = 33
+    BLUE = 34
+    MAGENTA = 35
+    CYAN = 36
+    WHITE = 37
+    RESET = 0
 
 
 class ConsoleColorFormatter(logging.Formatter):
@@ -13,17 +28,17 @@ class ConsoleColorFormatter(logging.Formatter):
 
     # ANSI escape codes for colored output
     colors = {
-        logging.DEBUG: 32,  # GREEN
-        15: 34,  # BLUE
-        logging.INFO: 36,  # CYAN
-        logging.WARNING: 33,  # YELLOW
-        logging.ERROR: 31,  # RED
+        logging.DEBUG: ANSIFGColorCodes.GREEN,
+        15: ANSIFGColorCodes.BLUE,
+        logging.INFO: ANSIFGColorCodes.CYAN,
+        logging.WARNING: ANSIFGColorCodes.YELLOW,
+        logging.ERROR: ANSIFGColorCodes.RED,
     }
 
     def format(self, record: logging.LogRecord) -> str:
         """Format log records as a colored plus sign followed by the log message."""
         color = self.colors.get(record.levelno, 0)
-        self._style._fmt = f"[\033[{color}m+\033[0m] %(message)s"  # noqa: W0212
+        self._style._fmt = f"[\033[{color.value}m+\033[0m] %(message)s"  # noqa: W0212
         return super().format(record)
 
 

--- a/src/yamlfix/entrypoints/__init__.py
+++ b/src/yamlfix/entrypoints/__init__.py
@@ -9,7 +9,7 @@ import sys
 from enum import Enum
 
 
-class ANSIFGColorCodes(Enum):
+class ANSIFGColorCode(Enum):
     """ANSI escape codes for colored output."""
 
     BLACK = 30
@@ -28,16 +28,16 @@ class ConsoleColorFormatter(logging.Formatter):
 
     # ANSI escape codes for colored output
     colors = {
-        logging.DEBUG: ANSIFGColorCodes.GREEN,
-        15: ANSIFGColorCodes.BLUE,
-        logging.INFO: ANSIFGColorCodes.CYAN,
-        logging.WARNING: ANSIFGColorCodes.YELLOW,
-        logging.ERROR: ANSIFGColorCodes.RED,
+        logging.DEBUG: ANSIFGColorCode.GREEN,
+        15: ANSIFGColorCode.BLUE,
+        logging.INFO: ANSIFGColorCode.CYAN,
+        logging.WARNING: ANSIFGColorCode.YELLOW,
+        logging.ERROR: ANSIFGColorCode.RED,
     }
 
     def format(self, record: logging.LogRecord) -> str:
         """Format log records as a colored plus sign followed by the log message."""
-        color = self.colors.get(record.levelno, 0)
+        color = self.colors.get(record.levelno, ANSIFGColorCode.RESET)
         self._style._fmt = f"[\033[{color.value}m+\033[0m] %(message)s"  # noqa: W0212
         return super().format(record)
 

--- a/src/yamlfix/entrypoints/__init__.py
+++ b/src/yamlfix/entrypoints/__init__.py
@@ -35,7 +35,7 @@ def load_logger(verbose: int = 0) -> None:
     """Configure the Logging logger.
 
     Args:
-        verbose: Set the logging level to Debug.
+        verbose: Decrease logging threshold by 10 for each level.
     """
     log_level = logging.WARNING - verbose * 10
     logging.basicConfig(stream=sys.stderr, level=log_level)

--- a/src/yamlfix/entrypoints/__init__.py
+++ b/src/yamlfix/entrypoints/__init__.py
@@ -46,7 +46,7 @@ def load_logger(verbose: int = 0) -> None:
     """Configure the Logging logger.
 
     Args:
-        verbose: Decrease logging threshold by 10 for each level.
+        verbose: Allow more detailed logging output.
     """
     log_level = logging.INFO - verbose * 5
     logging.basicConfig(stream=sys.stderr, level=log_level)

--- a/src/yamlfix/entrypoints/__init__.py
+++ b/src/yamlfix/entrypoints/__init__.py
@@ -31,13 +31,13 @@ class ConsoleColorFormatter(logging.Formatter):
         return super().format(record)
 
 
-def load_logger(verbose: bool = False) -> None:
+def load_logger(verbose: int = 0) -> None:
     """Configure the Logging logger.
 
     Args:
         verbose: Set the logging level to Debug.
     """
-    log_level = logging.DEBUG if verbose else logging.INFO
+    log_level = logging.WARNING - verbose * 10
     logging.basicConfig(stream=sys.stderr, level=log_level)
     for handler in logging.getLogger().handlers:
         handler.setFormatter(ConsoleColorFormatter())

--- a/src/yamlfix/entrypoints/__init__.py
+++ b/src/yamlfix/entrypoints/__init__.py
@@ -7,21 +7,17 @@ Functions:
 import logging
 import sys
 
-# Ansi color codes
-RED = 31
-YELLOW = 33
-CYAN = 36
-GREEN = 32
-
 
 class ConsoleColorFormatter(logging.Formatter):
     """Custom formatter that prints log levels to the console as colored plus signs."""
 
+    # ANSI escape codes for colored output
     colors = {
-        logging.DEBUG: GREEN,
-        logging.INFO: CYAN,
-        logging.WARNING: YELLOW,
-        logging.ERROR: RED,
+        logging.DEBUG: 32,  # GREEN
+        15: 34,  # BLUE
+        logging.INFO: 36,  # CYAN
+        logging.WARNING: 33,  # YELLOW
+        logging.ERROR: 31,  # RED
     }
 
     def format(self, record: logging.LogRecord) -> str:
@@ -37,7 +33,7 @@ def load_logger(verbose: int = 0) -> None:
     Args:
         verbose: Decrease logging threshold by 10 for each level.
     """
-    log_level = logging.WARNING - verbose * 10
+    log_level = logging.INFO - verbose * 5
     logging.basicConfig(stream=sys.stderr, level=log_level)
     for handler in logging.getLogger().handlers:
         handler.setFormatter(ConsoleColorFormatter())

--- a/src/yamlfix/entrypoints/__init__.py
+++ b/src/yamlfix/entrypoints/__init__.py
@@ -28,8 +28,11 @@ class ConsoleColorFormatter(logging.Formatter):
 
     # ANSI escape codes for colored output
     colors = {
-        logging.DEBUG: ANSIFGColorCode.GREEN,
-        15: ANSIFGColorCode.BLUE,
+        logging.DEBUG: ANSIFGColorCode.WHITE,
+        # There are only 2 named levels under WARNING, we need 3 levels of verbosity
+        # Using half-way between DEBUG and INFO as additional verbosity level
+        # It is currently used for logging unchanged files
+        15: ANSIFGColorCode.GREEN,
         logging.INFO: ANSIFGColorCode.CYAN,
         logging.WARNING: ANSIFGColorCode.YELLOW,
         logging.ERROR: ANSIFGColorCode.RED,

--- a/src/yamlfix/entrypoints/cli.py
+++ b/src/yamlfix/entrypoints/cli.py
@@ -29,7 +29,7 @@ def _find_all_yaml_files(dir_: Path) -> List[Path]:
 
 @click.command()
 @click.version_option(version="", message=version.version_info())
-@click.option("--verbose", is_flag=True, help="Enable verbose logging.")
+@click.option("--verbose", "-v", help="Enable verbose logging.", count=True)
 @click.option(
     "--check",
     is_flag=True,
@@ -81,11 +81,7 @@ def cli(
         sys.exit(0)
 
     load_logger(verbose)
-    log.info(
-        "%s files:%s",
-        "Checking" if check else "Fixing",
-        _format_file_list(files_to_fix),
-    )
+    log.warning("YamlFix: %s files", "Checking" if check else "Fixing")
 
     config = YamlfixConfig()
     configure_yamlfix(
@@ -98,7 +94,6 @@ def cli(
 
     if fixed_code is not None:
         print(fixed_code, end="")
-    log.info("Done.")
 
     if changed and check:
         sys.exit(1)

--- a/src/yamlfix/entrypoints/cli.py
+++ b/src/yamlfix/entrypoints/cli.py
@@ -17,11 +17,6 @@ from yamlfix.model import YamlfixConfig
 log = logging.getLogger(__name__)
 
 
-def _format_file_list(files: List[TextIOWrapper]) -> str:
-    file_names = [file.name for file in files]
-    return "\n  - ".join([""] + file_names)
-
-
 def _find_all_yaml_files(dir_: Path) -> List[Path]:
     files = [dir_.rglob(f"*.{ext}") for ext in ["yml", "yaml"]]
     return [file for list_ in files for file in list_]

--- a/src/yamlfix/entrypoints/cli.py
+++ b/src/yamlfix/entrypoints/cli.py
@@ -76,7 +76,7 @@ def cli(
         sys.exit(0)
 
     load_logger(verbose)
-    log.info("YamlFix: {} files".format("Checking" if check else "Fixing"))
+    log.info("YamlFix: %s files", "Checking" if check else "Fixing")
 
     config = YamlfixConfig()
     configure_yamlfix(

--- a/src/yamlfix/entrypoints/cli.py
+++ b/src/yamlfix/entrypoints/cli.py
@@ -76,7 +76,7 @@ def cli(
         sys.exit(0)
 
     load_logger(verbose)
-    log.warning("YamlFix: %s files", "Checking" if check else "Fixing")
+    log.info("YamlFix: %s files", "Checking" if check else "Fixing")
 
     config = YamlfixConfig()
     configure_yamlfix(

--- a/src/yamlfix/entrypoints/cli.py
+++ b/src/yamlfix/entrypoints/cli.py
@@ -76,7 +76,7 @@ def cli(
         sys.exit(0)
 
     load_logger(verbose)
-    log.info("YamlFix: %s files", "Checking" if check else "Fixing")
+    log.info("YamlFix: {} files".format("Checking" if check else "Fixing"))
 
     config = YamlfixConfig()
     configure_yamlfix(

--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -87,7 +87,7 @@ def fix_files(  # pylint: disable=too-many-branches
                 log.info("Would fix %s", file_name)
             else:
                 log.info("Fixed %s", file_name)
-            total_fixed += 1
+                total_fixed += 1
         else:
             log.log(15, "%s is already well formatted", file_name)
 

--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -36,9 +36,7 @@ def fix_files(
 
 
 def fix_files(  # pylint: disable=too-many-branches
-    files: Files,
-    dry_run: Optional[bool] = None,
-    config: Optional[YamlfixConfig] = None,
+    files: Files, dry_run: Optional[bool] = None, config: Optional[YamlfixConfig] = None
 ) -> Union[Optional[str], Tuple[Optional[str], bool]]:  # noqa: TAE002
     """Fix the yaml source code of a list of files.
 
@@ -69,6 +67,8 @@ def fix_files(  # pylint: disable=too-many-branches
             UserWarning,
         )
 
+    total_fixed = 0
+
     for file_ in files:
         if isinstance(file_, str):
             with open(file_, "r", encoding="utf-8") as file_descriptor:
@@ -83,15 +83,21 @@ def fix_files(  # pylint: disable=too-many-branches
 
         if fixed_source != source:
             changed = True
+            if dry_run:
+                log.warning("Would fix %s", file_name)
+            else:
+                log.warning("Fixed %s", file_name)
+            total_fixed += 1
+        else:
+            log.info("%s is already well formatted", file_name)
 
         if file_name == "<stdin>":
             if dry_run is None:
                 return fixed_source
-            return (fixed_source, changed)
+            return fixed_source, changed
 
         if fixed_source != source:
             if dry_run:
-                log.debug("Need to fix file %s.", file_name)
                 continue
             if isinstance(file_, str):
                 with open(file_, "w", encoding="utf-8") as file_descriptor:
@@ -100,14 +106,17 @@ def fix_files(  # pylint: disable=too-many-branches
                 file_.seek(0)
                 file_.write(fixed_source)
                 file_.truncate()
-            log.debug("Fixed file %s.", file_name)
-        else:
-            log.debug("Left file %s unmodified.", file_name)
+    log.warning(
+        "Checked %d files: %d fixed, %d left unchanged",
+        len(files),
+        total_fixed,
+        len(files) - total_fixed,
+    )
 
     if dry_run is None:
         return None
 
-    return (None, changed)
+    return None, changed
 
 
 def fix_code(source_code: str, config: Optional[YamlfixConfig] = None) -> str:

--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -84,12 +84,12 @@ def fix_files(  # pylint: disable=too-many-branches
         if fixed_source != source:
             changed = True
             if dry_run:
-                log.warning("Would fix %s", file_name)
+                log.info("Would fix %s", file_name)
             else:
-                log.warning("Fixed %s", file_name)
+                log.info("Fixed %s", file_name)
             total_fixed += 1
         else:
-            log.info("%s is already well formatted", file_name)
+            log.log(15, "%s is already well formatted", file_name)
 
         if file_name == "<stdin>":
             if dry_run is None:
@@ -106,7 +106,7 @@ def fix_files(  # pylint: disable=too-many-branches
                 file_.seek(0)
                 file_.write(fixed_source)
                 file_.truncate()
-    log.warning(
+    log.info(
         "Checked %d files: %d fixed, %d left unchanged",
         len(files),
         total_fixed,

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -27,8 +27,7 @@ def test_version(runner: CliRunner) -> None:
 
     assert result.exit_code == 0
     assert re.search(
-        rf" *yamlfix: {__version__}\n *Python: .*\n *Platform: .*",
-        result.stdout,
+        rf" *yamlfix: {__version__}\n *Python: .*\n *Platform: .*", result.stdout
     )
 
 

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -105,17 +105,17 @@ def test_verbose_option(runner: CliRunner, verbose: int, requires_fixing: bool) 
 
     result = runner.invoke(cli, args, input=source)
 
-    warning_log_format = "[\033[33m+\033[0m]"
     debug_log_format = "[\033[32m+\033[0m]"
+    unchanged_log_format = "[\033[34m+\033[0m]"
     info_log_format = "[\033[36m+\033[0m]"
-    assert (f"{warning_log_format} Fixed <stdin>" in result.stderr) == requires_fixing
+    # Check that changes are printed at info level
+    assert (f"{info_log_format} Fixed <stdin>" in result.stderr) == requires_fixing
     if verbose == 0:
         assert debug_log_format not in result.stderr
-        assert info_log_format not in result.stderr
-        # Check that changes are printed at warning level
+        assert unchanged_log_format not in result.stderr
     if verbose >= 1:
-        # If no changes are not required, info log should not be printed
-        assert (info_log_format in result.stderr) != requires_fixing
+        # If no changes are required, unchanged log should not be printed
+        assert (unchanged_log_format in result.stderr) != requires_fixing
     if verbose >= 2:
         assert debug_log_format in result.stderr
 
@@ -135,7 +135,7 @@ def test_ignores_correct_files(
     assert test_file.read_text() == "---\na: 1\n"
     assert (
         "yamlfix.services",
-        logging.INFO,
+        15,
         f"{test_file} is already well formatted",
     ) in caplog.record_tuples
 

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -104,8 +104,8 @@ def test_verbose_option(runner: CliRunner, verbose: int, requires_fixing: bool) 
 
     result = runner.invoke(cli, args, input=source)
 
-    debug_log_format = "[\033[32m+\033[0m]"
-    unchanged_log_format = "[\033[34m+\033[0m]"
+    debug_log_format = "[\033[37m+\033[0m]"
+    unchanged_log_format = "[\033[32m+\033[0m]"
     info_log_format = "[\033[36m+\033[0m]"
     # Check that changes are printed at info level
     assert (f"{info_log_format} Fixed <stdin>" in result.stderr) == requires_fixing

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -97,7 +97,11 @@ def test_verbose_option(runner: CliRunner, verbose: int, requires_fixing: bool) 
     # For more info see https://github.com/pallets/click/issues/1053)
     logging.getLogger().handlers = []
     source = "program: yamlfix" if requires_fixing else "---\nprogram: yamlfix\n"
-    args = ["-"] + ["-v"] * verbose
+    args = ["-"]
+    if verbose >= 1:
+        args.append("--verbose")
+    if verbose >= 2:
+        args.append("-v")
 
     result = runner.invoke(cli, args, input=source)
 


### PR DESCRIPTION
Only list changed files by default

Fixes #216

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes

Current behaviour:
* No flag: Print summary and changed files at `INFO` level
* One flag: + print unchanged files at `15` level
* Two+ flags: + print `DEBUG` information.

Also, added short version of `--verbose` flag (`-v`) and changed it to counter, so any combination (e.g. `-v -v`, `-vv`, `-v --vebose`) should work.
