### PR TITLE
fix: account for explicit_start=False when handling whitelines

### DIFF
--- a/src/yamlfix/adapters.py
+++ b/src/yamlfix/adapters.py
@@ -673,7 +673,9 @@ class SourceCodeFixer:
 
     def _fix_section_whitelines(self, source_code: str) -> str:
         re_section = "\n*(^#.*\n)*\n*^[^ ].*:\n(\n|(^  .*))+\n*"
-        re_beginning_section = f"(?P<b>---\n{re_section})"
+        # Match the first --- or start of the string \A
+        # See: https://docs.python.org/3.9/library/re.html#regular-expression-syntax
+        re_beginning_section = f"(?P<b>(?:---\n|\\A){re_section})"
         re_normal_section = f"(?P<s>{re_section})"
         re_full = f"{re_beginning_section}|{re_normal_section}"
         pattern = re.compile(re_full, flags=re.MULTILINE)

--- a/tests/unit/test_adapter_yaml.py
+++ b/tests/unit/test_adapter_yaml.py
@@ -670,3 +670,28 @@ class TestYamlAdapter:
         result = fix_code(source, config)
 
         assert result == fixed_source
+
+    def test_section_whitelines_begin_no_explicit_start(self) -> None:
+        """Check that no whitelines are added at start of file when explicit start \
+            is not applied."""
+        source = dedent(
+            # pylint: disable=C0303
+            """\
+            begin_section: 
+              key: value
+            """  # noqa: W291
+        )
+        fixed_source = dedent(
+            """\
+            begin_section:
+              key: value
+            """
+        )
+        config = YamlfixConfig()
+        config.section_whitelines = 1
+        config.comments_whitelines = 2
+        config.explicit_start = False
+
+        result = fix_code(source, config)
+
+        assert result == fixed_source


### PR DESCRIPTION
The regex would check for `---\n` as the file start which would not necessarily apply if `explicit_start=False`. This change also considers `\A` as an alternative file start.

I wasn't able to find an open issue to link this change to. Please advise if any documentation is required for this change.

## Checklist

* [x] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
