### PR TITLE
Swap rev from master to main

### DIFF
--- a/docs/editor_integration.md
+++ b/docs/editor_integration.md
@@ -26,7 +26,7 @@ You'll need to add the following lines to your project's
 ```yaml
 repos:
   - repo: https://github.com/lyz-code/yamlfix/
-    rev: master
+    rev: main
     hooks:
       - id: yamlfix
 ```


### PR DESCRIPTION
Upstream repo is using 'main' as the default branch

<!-- Describe what the change is, trying to link it with open issues -->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
