### PR TITLE
Remove duplicate entry in 'Features' summary

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,6 @@ variable, use `fix_code`:
   [POSIX standard](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206).
 - Split long lines.
 - Respect Jinja2 syntax.
-- Ensure a `\n` exists at the end of the file.
 - Convert short lists to flow-style `list: [item, item]`
 - Convert lists longer than line-width to block-style:
   ```yaml


### PR DESCRIPTION
Hi, I noticed that two bullet points in `Features` on the docs page tell the same thing using different words:

- Ensure that there is exactly one newline at the end of each file, to comply with the [POSIX standard](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206).
- Ensure a `\n` exists at the end of the file.

I guess that the latter can be removed.

## Checklist

* [ ] **N/A** Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
