### PR TITLE
add --- to 'after' example in 'Usage' section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,11 +30,13 @@ It has the following errors:
 After running `yamlfix` the resulting source code will be:
 
 ```yaml
+---
 book_library:
   - title: Why we sleep
     author: Matthew Walker
   - title: Harry Potter and the Methods of Rationality
     author: Eliezer Yudkowsky
+
 ```
 
 `yamlfix` can be used both as command line tool and as a library.


### PR DESCRIPTION
The example in the docs/index.md#Usage section says that '---' will be added to the file. Then shows the 'after yamlfix' example with no --- added.
I ran yamlfix on the example file and pasted the result.
This seemed small enough to not make an issue first, please correct me if I am wrong.