### PR TITLE
add --- to 'after' in usage example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ It has the following errors:
 After running `yamlfix` the resulting source code will be:
 
 ```yaml
+---
 book_library:
   - title: Why we sleep
     author: Matthew Walker


### PR DESCRIPTION
Usage example states that '---' will be added to the start of a yamlfile when running yamlfix. However the example in the usage section did not show this.
I ran the example through yamlfix and changed the 'after' example here accordingly.

Didn't understand why the previous PR was willing to change 600+ lines just to modify this 1. Oh well.
Ran this again(again) bevcause the pdm installation failed in the PR and locally for me. But now it works locally, so hopefully the PR can also be successful.