### PR TITLE
Allow wildcarding nested dirs in exclusion logic

### DIFF
--- a/src/yamlfix/entrypoints/cli.py
+++ b/src/yamlfix/entrypoints/cli.py
@@ -17,8 +17,10 @@ from yamlfix.model import YamlfixConfig
 log = logging.getLogger(__name__)
 
 
-def _matches_any_glob(file_to_test: Path, globs: Optional[List[str]]) -> bool:
-    return any(file_to_test.match(glob) for glob in (globs or []))
+def _matches_any_glob(
+    file_to_test: Path, dir_: Path, globs: Optional[List[str]]
+) -> bool:
+    return any(file_to_test in dir_.glob(glob) for glob in (globs or []))
 
 
 def _find_all_yaml_files(
@@ -29,7 +31,7 @@ def _find_all_yaml_files(
         file
         for list_ in files
         for file in list_
-        if not _matches_any_glob(file, exclude_globs)
+        if not _matches_any_glob(file, dir_, exclude_globs)
     ]
 
 

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -92,7 +92,11 @@ def test_include_exclude_files(runner: CliRunner, tmp_path: Path) -> None:
     exclude1 = tmp_path / "source_2.txt"
     (tmp_path / "foo").mkdir()
     exclude2 = tmp_path / "foo" / "source_3.yaml"
-    test_files = [include1, exclude1, exclude2]
+    (tmp_path / "foo" / "bar").mkdir()
+    exclude3 = tmp_path / "foo" / "bar" / "source_4.yaml"
+    (tmp_path / "foo" / "baz").mkdir()
+    exclude4 = tmp_path / "foo" / "baz" / "source_5.yaml"
+    test_files = [include1, exclude1, exclude2, exclude3, exclude4]
     init_source = "program: yamlfix"
     for test_file in test_files:
         test_file.write_text(init_source)
@@ -105,13 +109,23 @@ def test_include_exclude_files(runner: CliRunner, tmp_path: Path) -> None:
 
     result = runner.invoke(
         cli,
-        [str(tmp_path)] + ["--include", "*.yaml", "--exclude", "foo/*.yaml"],
+        [str(tmp_path)]
+        + [
+            "--include",
+            "*.yaml",
+            "--exclude",
+            "foo/*.yaml",
+            "--exclude",
+            "foo/**/*.yaml",
+        ],
     )
 
     assert result.exit_code == 0
     assert include1.read_text() == fixed_source
     assert exclude1.read_text() == init_source
     assert exclude2.read_text() == init_source
+    assert exclude3.read_text() == init_source
+    assert exclude4.read_text() == init_source
 
 
 @pytest.mark.secondary()


### PR DESCRIPTION
This allows for excluding whole directories recursively, rather than just at a top level as previous. The motivation for this change was wanting to exclude a whole directory, e.g. a virtual environment `venv/**/*` or a compiled target directory with multiple subdirectories: `**/target/**/*`.