### PR TITLE
Bug fix: ignore folders that look like yaml files.

### DIFF
--- a/src/yamlfix/entrypoints/cli.py
+++ b/src/yamlfix/entrypoints/cli.py
@@ -31,7 +31,7 @@ def _find_all_yaml_files(
         file
         for list_ in files
         for file in list_
-        if not _matches_any_glob(file, dir_, exclude_globs)
+        if not _matches_any_glob(file, dir_, exclude_globs) and os.path.isfile(file)
     ]
 
 

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -7,6 +7,7 @@ from itertools import product
 from pathlib import Path
 from textwrap import dedent
 
+import py  # type: ignore
 import pytest
 from _pytest.logging import LogCaptureFixture
 from click.testing import CliRunner
@@ -410,3 +411,12 @@ def test_std_and_file_error(runner: CliRunner, tmp_path: Path) -> None:
     assert (
         str(result.exception) == "Cannot specify '-' and other files at the same time."
     )
+
+
+def test_do_not_read_folders_as_files(runner: CliRunner, tmpdir: py.path.local) -> None:
+    """Skips folders that have a .yml or .yaml extension."""
+    tmpdir.mkdir("folder.yml")
+
+    result = runner.invoke(cli, [str(tmpdir)])
+
+    assert result.exit_code == 0


### PR DESCRIPTION
Fixed a bug that yamlfix crashes when it encounters a folder that looks like a yaml file (e.g. folder.yml or folder.yaml).

See issue #256 

## Checklist

* [X] Add test cases to all the changes you introduce
* [X] Update the documentation for the changes -> not needed?
