### PR TITLE
preserv ansible # jinja2 header

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ source-includes = ["tests/"]
 [tool.pdm.build]
 editable-backend = "path"
 
-[tool.pdm.overrides]
+[tool.pdm.resolution.overrides]
 
 # To be removed once https://github.com/flakeheaven/flakeheaven/issues/132 is solved
 "importlib-metadata" = ">=3.10"

--- a/src/yamlfix/services.py
+++ b/src/yamlfix/services.py
@@ -149,9 +149,16 @@ def fix_code(source_code: str, config: Optional[YamlfixConfig] = None) -> str:
     else:
         shebang = ""
 
+    if source_code.startswith("#jinja2:") or source_code.startswith("# jinja2:"):
+        eolpos = source_code.find("\n") + 1
+        jinja2 = source_code[:eolpos]
+        source_code = source_code[eolpos:]
+    else:
+        jinja2 = ""
+
     yaml = Yaml(config=config)
     fixer = SourceCodeFixer(yaml=yaml, config=config)
 
     source_code = fixer.fix(source_code=source_code)
 
-    return shebang + source_code
+    return jinja2 + shebang + source_code

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -74,6 +74,20 @@ class TestFixFiles:
 class TestFixCode:
     """Test the fix_code function."""
 
+    def test_fix_code_ignore_jinja2(self) -> None:
+        """Ignores jinja2 line if present at the beginning of the source."""
+        source = dedent(
+            """\
+            # jinja2:lstrip_blocks: true
+            ---
+            program: yamlfix
+            """
+        )
+
+        result = fix_code(source)
+
+        assert result == source
+
     def test_fix_code_ignore_shebang(self) -> None:
         """Ignores shebang lines if present at the beginning of the source."""
         source = dedent(


### PR DESCRIPTION
Preserves the jinja2 ansible headers `# jinja2:` like: `# jinja2:lstrip_blocks: true`

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/template_module.html

 > Also, you can override jinja2 settings by adding a special header to template file. i.e. 
#jinja2:variable_start_string:'[%', variable_end_string:'%]', trim_blocks: False 

Useful when using `jinja2.ansible`:

```yaml
#jinja2:lstrip_blocks: True
# ----------------------------------------------------------------------------
# {{ ansible_managed }}
# ----------------------------------------------------------------------------
---
global:
  resolve_timeout: 1m'

route:
...
```

## Checklist

* [X] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
