### PR TITLE
Set an upper bound limit on Maison dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.8"
 dependencies = [
     "click>=8.1.3",
     "ruyaml>=0.91.0",
-    "maison>=1.4.0",
+    "maison>=1.4.0,<2.0.0",
 ]
 name = "yamlfix"
 description = "A simple opionated yaml formatter that keeps your comments!"


### PR DESCRIPTION
Since the release of Maison 2.0.0 on August 19th, yamlfix installation is broken since it's not compatible with this version and doesn't set any upper bound cap on the dependency.
This PR adds a hard limit to only accept versions prior to 2.0

Closes #286 

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
