### PR TITLE
Perform exclude glob only once per dir

### DIFF
--- a/src/yamlfix/entrypoints/cli.py
+++ b/src/yamlfix/entrypoints/cli.py
@@ -17,22 +17,12 @@ from yamlfix.model import YamlfixConfig
 log = logging.getLogger(__name__)
 
 
-def _matches_any_glob(
-    file_to_test: Path, dir_: Path, globs: Optional[List[str]]
-) -> bool:
-    return any(file_to_test in dir_.glob(glob) for glob in (globs or []))
-
-
 def _find_all_yaml_files(
-    dir_: Path, include_globs: Optional[List[str]], exclude_globs: Optional[List[str]]
+    dir_: Path, include_globs: List[str], exclude_globs: Optional[List[str]]
 ) -> List[Path]:
-    files = [dir_.rglob(glob) for glob in (include_globs or [])]
-    return [
-        file
-        for list_ in files
-        for file in list_
-        if not _matches_any_glob(file, dir_, exclude_globs) and os.path.isfile(file)
-    ]
+    files = {f for glob in (include_globs) for f in dir_.rglob(glob) if f.is_file()}
+    files.difference_update(f for exc in (exclude_globs or []) for f in dir_.rglob(exc))
+    return sorted(files)
 
 
 @click.command()
@@ -80,7 +70,7 @@ def cli(  # pylint: disable=too-many-arguments
     verbose: bool,
     check: bool,
     config_file: Optional[List[str]],
-    include: Optional[List[str]],
+    include: List[str],
     exclude: Optional[List[str]],
     env_prefix: str,
 ) -> None:


### PR DESCRIPTION
Change the file enumeration method to only execute the glob once per dir instead of once per file. Does not change the behavior except that it will be much faster if using a dir to specify the location and glob exclude patterns that need to be evaluated over many files.

Additionally:
- fix the type for `include` the include pattern which is always present since there is a default value therefore not optional
- use a set for the files such that applying exclusion patterns is fast and the same file won't be processed twice in case the include patterns happen to include the same file multiple times

## Checklist

* [ ] Add test cases to all the changes you introduce → no behavior changes
* [ ] Update the documentation for the changes → no behavior changes
