### PR TITLE
fix: limit inline # formatting to lines that do not begin with #

### DIFF
--- a/src/yamlfix/adapters.py
+++ b/src/yamlfix/adapters.py
@@ -586,6 +586,7 @@ class SourceCodeFixer:
                 config.comments_min_spaces_from_content > 1
                 and " #" in line
                 and line[-1] not in ["'", '"']
+                and not line.lstrip().startswith("#")
             ):
                 line = re.sub(
                     r"^([^\"']*[^\"' \t])(\s+?)#", rf"\1{comment_start}", line

--- a/tests/unit/test_adapter_yaml.py
+++ b/tests/unit/test_adapter_yaml.py
@@ -81,6 +81,8 @@ class TestYamlAdapter:
             # comment
             project_name: yamlfix #comment
             "key #1": 'value #2'
+            #   comment
+            #      #!/usr/bin/env bash
             """
         )
         fixed_source = dedent(
@@ -89,6 +91,8 @@ class TestYamlAdapter:
             # comment
             project_name: yamlfix  # comment
             'key #1': 'value #2'
+            #   comment
+            #      #!/usr/bin/env bash
             """
         )
         config = YamlfixConfig()


### PR DESCRIPTION
Fixes #295 and a related bug introduced in de50bfb4fdf43b8921ce3cfe02c2be1833188b28.

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes (n/a)
